### PR TITLE
chore: add .gitattributes for ios pbxproj file

### DIFF
--- a/packages/climbingapp/ios/climbingApp/.gitattributes
+++ b/packages/climbingapp/ios/climbingApp/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj -crlf -diff -merge


### PR DESCRIPTION
## Description
- xcode의 최상위 프로젝트 관리 패키지인 .pbxproj 파일은 ide 등 로컬 환경에 의해 변경되어 conflict가 발생할 수 있으나 gitignore에는 넣을 수 없는 이슈.
- gitattributes 파일을 만들어 병합되지 않고 비교 되지 않게 하는 방법으로 우회


## Changes detail
- 아래 옵션 부여
  - crlf : crlf <=> cr 변환을 사용하지 않. 
  - diff : 파일을 diff하지 않음.
  - merge : 파일을 병합하지 않음.