### PR TITLE
chore: redux store and slices setting

### DIFF
--- a/packages/climbingapp/App.tsx
+++ b/packages/climbingapp/App.tsx
@@ -3,6 +3,9 @@ import { ThemeProvider } from 'styled-components';
 import { light } from './src/theme';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { NavigationContainer } from '@react-navigation/native';
+import store from './src/store';
+import { Provider } from 'react-redux';
+
 import MainNavigator from './src/navigation/MainNavigator';
 import LoginNavigator from './src/navigation/LoginNavigator';
 
@@ -10,13 +13,15 @@ const isLoggedIn = true;
 
 const App = () => {
   return (
-    <SafeAreaProvider>
-      <ThemeProvider theme={light}>
-        <NavigationContainer>
-          {isLoggedIn ? <MainNavigator /> : <LoginNavigator />}
-        </NavigationContainer>
-      </ThemeProvider>
-    </SafeAreaProvider>
+    <Provider store={store}>
+      <SafeAreaProvider>
+        <ThemeProvider theme={light}>
+          <NavigationContainer>
+            {isLoggedIn ? <MainNavigator /> : <LoginNavigator />}
+          </NavigationContainer>
+        </ThemeProvider>
+      </SafeAreaProvider>
+    </Provider>
   );
 };
 

--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -1,0 +1,19 @@
+import { authorize, logout } from 'climbingapp/src/store/slices/auth';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from 'climbingapp/src/store/slices';
+import { bindActionCreators } from 'redux';
+
+const useUser = () => {
+  return useSelector((state: RootState) => state.auth.user);
+};
+
+const useAuthActions = () => {
+  const dispatch = useDispatch();
+  return bindActionCreators({ authorize, logout }, dispatch);
+};
+
+export const useAuth = () => {
+  const user = useUser();
+  const authAction = useAuthActions();
+  return { user, authorize: authAction.authorize, logout: authAction.logout };
+};

--- a/packages/climbingapp/src/store/index.ts
+++ b/packages/climbingapp/src/store/index.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { useDispatch } from 'react-redux';
+import rootReducer from './slices';
+
+const store = configureStore({
+  reducer: rootReducer,
+});
+
+export type AppDispatch = typeof store.dispatch;
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+
+export default store;

--- a/packages/climbingapp/src/store/slices/auth.ts
+++ b/packages/climbingapp/src/store/slices/auth.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface User {
+  id: number;
+  username: string;
+  displayName?: string | null;
+}
+
+interface AuthState {
+  user: User | null;
+}
+
+const initialState: AuthState = {
+  user: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    authorize(state, action: PayloadAction<User>) {
+      state.user = action.payload;
+    },
+    logout(state) {
+      state.user = null;
+    },
+  },
+});
+
+export default authSlice.reducer;
+export const { authorize, logout } = authSlice.actions;

--- a/packages/climbingapp/src/store/slices/index.ts
+++ b/packages/climbingapp/src/store/slices/index.ts
@@ -1,0 +1,10 @@
+import { combineReducers } from 'redux';
+import auth from './auth';
+
+const rootReducer = combineReducers({
+  auth,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+export default rootReducer;


### PR DESCRIPTION
## Related issue
- \#37

## Description
- RN redux store, slice 생성
- demo 코드로 auth slice 구현 => 추후 UserInfo에 필요한 속성 추가
- useAuth 훅 구현 => 추후 변경할 수 있음

## Changes detail
- store 생성 및 app.tsx 파일에 적용 
  - Provider가 있는 파일에서 직접적으로 data read, write 불가, 하위 컴포넌트에서 redux 사용 
- auth slice에서 reducer 함수를 정의하고 rootReducer에 등록
- useAuth를 통해 hook 형식으로 state, function 제공