### PR TITLE
Dropdown and bottom sheet

### DIFF
--- a/packages/climbingapp/App.tsx
+++ b/packages/climbingapp/App.tsx
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 
 import MainNavigator from './src/navigation/MainNavigator';
 import LoginNavigator from './src/navigation/LoginNavigator';
-
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 const isLoggedIn = true;
 
 const App = () => {
@@ -16,9 +16,11 @@ const App = () => {
     <Provider store={store}>
       <SafeAreaProvider>
         <ThemeProvider theme={light}>
-          <NavigationContainer>
-            {isLoggedIn ? <MainNavigator /> : <LoginNavigator />}
-          </NavigationContainer>
+          <BottomSheetModalProvider>
+            <NavigationContainer>
+              {isLoggedIn ? <MainNavigator /> : <LoginNavigator />}
+            </NavigationContainer>
+          </BottomSheetModalProvider>
         </ThemeProvider>
       </SafeAreaProvider>
     </Provider>

--- a/packages/climbingapp/babel.config.js
+++ b/packages/climbingapp/babel.config.js
@@ -35,5 +35,6 @@ module.exports = {
         ],
       },
     ],
+    'react-native-reanimated/plugin',
   ],
 };

--- a/packages/climbingapp/index.js
+++ b/packages/climbingapp/index.js
@@ -1,7 +1,7 @@
 /**
  * @format
  */
-
+import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';

--- a/packages/climbingapp/ios/Podfile.lock
+++ b/packages/climbingapp/ios/Podfile.lock
@@ -349,6 +349,35 @@ PODS:
     - React-perflogger (= 0.67.4)
   - RNCMaskedView (0.2.6):
     - React-Core
+  - RNGestureHandler (2.4.2):
+    - React-Core
+  - RNReanimated (2.8.0):
+    - DoubleConversion
+    - FBLazyVector
+    - FBReactNativeSpec
+    - glog
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-Core/DevSupport
+    - React-Core/RCTWebSocket
+    - React-CoreModules
+    - React-cxxreact
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-RCTActionSheet
+    - React-RCTAnimation
+    - React-RCTBlob
+    - React-RCTImage
+    - React-RCTLinking
+    - React-RCTNetwork
+    - React-RCTSettings
+    - React-RCTText
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNScreens (3.13.1):
     - React-Core
     - React-RCTImage
@@ -416,6 +445,8 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../../../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../../../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../../../node_modules/@react-native-masked-view/masked-view`)"
+  - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
+  - RNReanimated (from `../../../node_modules/react-native-reanimated`)
   - RNScreens (from `../../../node_modules/react-native-screens`)
   - RNSVG (from `../../../node_modules/react-native-svg`)
   - Yoga (from `../../../node_modules/react-native/ReactCommon/yoga`)
@@ -504,6 +535,10 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon"
   RNCMaskedView:
     :path: "../../../node_modules/@react-native-masked-view/masked-view"
+  RNGestureHandler:
+    :path: "../../../node_modules/react-native-gesture-handler"
+  RNReanimated:
+    :path: "../../../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../../../node_modules/react-native-screens"
   RNSVG:
@@ -558,6 +593,8 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: a9d3c82ddf7ffdad9fbe6a81c6d6f8c06385464d
   ReactCommon: 07d0c460b9ba9af3eaf1b8f5abe7daaad28c9c4e
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
+  RNGestureHandler: 61628a2c859172551aa2100d3e73d1e57878392f
+  RNReanimated: 46cdb89ca59ab7181334f4ed05a70e82ddb36751
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Yoga: d6b6a80659aa3e91aaba01d0012e7edcbedcbecd

--- a/packages/climbingapp/package.json
+++ b/packages/climbingapp/package.json
@@ -10,13 +10,16 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^4",
     "@react-native-masked-view/masked-view": "^0.2.6",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/material-top-tabs": "^6.2.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
     "react-native": "0.67.4",
+    "react-native-gesture-handler": "^2.4.2",
     "react-native-pager-view": "^5.4.17",
+    "react-native-reanimated": "^2.8.0",
     "react-native-safe-area-context": "^4.2.5",
     "react-native-screens": "^3.13.1",
     "react-native-svg": "^12.3.0",

--- a/packages/climbingapp/src/component/bottomSheet/BottomSheet.tsx
+++ b/packages/climbingapp/src/component/bottomSheet/BottomSheet.tsx
@@ -1,0 +1,91 @@
+import React, { useCallback, useMemo } from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { BottomSheetFlatList, BottomSheetModal } from '@gorhom/bottom-sheet';
+import { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
+import { colorStyles } from 'climbingapp/src/styles';
+import styled from 'styled-components/native';
+
+interface BottomSheetProps {
+    data: string[];
+    onEachItemPress: (({ }: any) => void);
+}
+
+const MyBottomSheet = React.forwardRef<BottomSheetModalMethods, BottomSheetProps>(({ onEachItemPress, data }, ref) => {
+
+    const snapPoints = useMemo(() => ['25%', '50%'], []);
+
+    const styles = StyleSheet.create({
+        container: {
+            flex: 1,
+            padding: 24,
+            justifyContent: 'center',
+            backgroundColor: 'grey',
+        },
+        contentContainer: {
+            flex: 1,
+            paddingLeft: 20,
+            alignItems: 'flex-start'
+        },
+        itemContainer: {
+            padding: 6,
+            margin: 6,
+            width: '100%',
+            backgroundColor: `${colorStyles.White}`,
+        },
+        headContainer: {
+            padding: 6,
+            margin: 6,
+            width: '100%',
+            backgroundColor: `${colorStyles.White}`,
+        }
+    });
+    // renders
+    const Divider = styled.View`
+        background-color: ${colorStyles.Gray300};
+        height: 1px;
+    `;
+
+    const renderItem = useCallback(
+        ({ item }) => (
+            <Pressable style={styles.itemContainer} onPress={onEachItemPress}>
+                <Text>{item}</Text>
+            </Pressable>
+        ),
+        []
+    );
+
+
+    const Header = useCallback(
+        () => (
+            <>
+                <View style={styles.headContainer}>
+                    <Text style={{ fontWeight: 'bold', color: '#333333' }}>시 도 선택</Text>
+                </View>
+                <Divider />
+            </>
+        ),
+        []
+    );
+
+    return (
+        <>
+            <BottomSheetModal
+                enablePanDownToClose
+                ref={ref}
+                index={1}
+                snapPoints={snapPoints}
+            >
+                <BottomSheetFlatList
+                    data={data}
+                    ListHeaderComponent={Header}
+                    ListHeaderComponentStyle={{ width: '95%' }}
+                    renderItem={renderItem}
+                    contentContainerStyle={styles.contentContainer}
+                    scrollEnabled={true}
+                />
+            </BottomSheetModal>
+        </>
+    );
+});
+
+export default MyBottomSheet;

--- a/packages/climbingapp/src/component/dropdown/DropDown.stories.tsx
+++ b/packages/climbingapp/src/component/dropdown/DropDown.stories.tsx
@@ -1,0 +1,10 @@
+import { ComponentMeta } from '@storybook/react';
+import { AreaDropDown } from './DropDown';
+
+export default {
+    title: 'App/DropDown',
+    component: AreaDropDown,
+} as ComponentMeta<typeof AreaDropDown>;
+
+export const FirtDropDown = () => <AreaDropDown placeholder='도·시' value='' />;
+export const SecondDropDown = () => <AreaDropDown placeholder='시·군·구' value='' />;

--- a/packages/climbingapp/src/component/dropdown/DropDown.tsx
+++ b/packages/climbingapp/src/component/dropdown/DropDown.tsx
@@ -1,0 +1,48 @@
+import { colorStyles } from 'climbingapp/src/styles';
+import React from 'react';
+import { Pressable } from 'react-native';
+import styled from 'styled-components/native';
+import ArrowDown from '../../assets/icon/ic_20_arrow_down_gray400.svg';
+
+interface DropDownProps {
+    placeholder: string | undefined;
+    value: string;
+    onPress: ({ }: any) => void;
+}
+
+export const DropDown = styled.View`
+    width: 156px;
+    height: 52px;
+    display: flex;
+    align-items: center;
+    border-radius: 8px;
+    gap: 16px;
+    border: 1px solid ${colorStyles.Gray300};
+    background-color: ${colorStyles.White};
+    position: absolute;
+`;
+
+const Input = styled.TextInput`
+    width: 88px;
+    font-size: 14px;
+    color: ${colorStyles.Gray400};
+`;
+const DropInput = styled.View`
+    flex-direction: row;
+    padding: 16px;
+    justify-content: space-around;
+`;
+
+
+export const AreaDropDown = ({ value, placeholder, onPress }: DropDownProps) => {
+    return (
+        <DropDown>
+            <DropInput>
+                <Input placeholder={placeholder} value={value} editable={false} placeholderTextColor={colorStyles.Gray400} />
+                <Pressable onPress={onPress}>
+                    <ArrowDown />
+                </Pressable>
+            </DropInput>
+        </DropDown>
+    );
+};

--- a/packages/climbingapp/src/navigation/screens/main/BoardScreen.tsx
+++ b/packages/climbingapp/src/navigation/screens/main/BoardScreen.tsx
@@ -1,16 +1,33 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Text } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { View } from 'react-native';
 import Insta from '../../../assets/icon/ic_20_instagram.svg';
+import { AreaDropDown } from 'climbingapp/src/component/dropdown/DropDown';
+import MyBottomSheet from 'climbingapp/src/component/bottomSheet/BottomSheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+
 const TopTab = createMaterialTopTabNavigator();
 
 export const FreeScreen = () => {
     return <View><Text><Insta /></Text></View>;
 };
+
 const MemeberScreen = () => {
-    return <View><Text>MemberScreen</Text></View>;
+    const ref = useRef<BottomSheetModal>(null);
+    const data = ['서울 특별시', '부산 광역시', '서울 특별시', '부산 광역시', '서울 특별시', '부산 광역시'];
+    const handleRef = () => {
+        console.log(ref);
+        ref.current?.present();
+    };
+    const handleChoiceItem = () => {
+        console.log(ref);
+        ref.current?.close();
+    };
+
+    return <View><AreaDropDown placeholder='시군' value='' onPress={handleRef} /><MyBottomSheet data={data} ref={ref} onEachItemPress={handleChoiceItem} /></View>;
 };
+
 
 function BoardScreen() {
     return (

--- a/packages/climbingapp/src/store/slices/index.ts
+++ b/packages/climbingapp/src/store/slices/index.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from 'redux';
 import auth from './auth';
-
 const rootReducer = combineReducers({
   auth,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,6 +902,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
+"@babel/plugin-syntax-typescript@^7.17.12":
+  version "7.17.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.17.12.tgz#b54fc3be6de734a56b87508f99d6428b5b605a7b"
+  integrity sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.17.12"
+
 "@babel/plugin-transform-arrow-functions@^7.0.0", "@babel/plugin-transform-arrow-functions@^7.12.1", "@babel/plugin-transform-arrow-functions@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz#44125e653d94b98db76369de9c396dc14bef4154"
@@ -1198,7 +1205,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.17.12"
 
-"@babel/plugin-transform-object-assign@^7.0.0":
+"@babel/plugin-transform-object-assign@^7.0.0", "@babel/plugin-transform-object-assign@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.16.7.tgz#5fe08d63dccfeb6a33aa2638faf98e5c584100f8"
   integrity sha512-R8mawvm3x0COTJtveuoqZIjNypn2FjfvXZr4pSQ8VhEFBuQGBz4XhHasZtHXjgXU4XptZ4HtGof3NoYc93ZH9Q==
@@ -1406,6 +1413,15 @@
     "@babel/helper-create-class-features-plugin" "^7.16.7"
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-typescript" "^7.16.7"
+
+"@babel/plugin-transform-typescript@^7.17.12":
+  version "7.18.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.4.tgz#587eaf6a39edb8c06215e550dc939faeadd750bf"
+  integrity sha512-l4vHuSLUajptpHNEOUDEGsnpl9pfRLsN1XUoDQDD/YBuXTM+v37SHGS+c6n4jdcZy96QtuUuSvZYMLSSsjH8Mw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.18.0"
+    "@babel/helper-plugin-utils" "^7.17.12"
+    "@babel/plugin-syntax-typescript" "^7.17.12"
 
 "@babel/plugin-transform-unicode-escapes@^7.16.7":
   version "7.16.7"
@@ -1636,6 +1652,15 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.16.7"
 
+"@babel/preset-typescript@^7.16.7":
+  version "7.17.12"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.17.12.tgz#40269e0a0084d56fc5731b6c40febe1c9a4a3e8c"
+  integrity sha512-S1ViF8W2QwAKUGJXxP9NAfNaqGDdEBJKpYkxHf5Yy2C4NPPzXGeR3Lhk7G8xJaaLcFTRfNjVbtbVtm8Gb0mqvg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.17.12"
+    "@babel/helper-validator-option" "^7.16.7"
+    "@babel/plugin-transform-typescript" "^7.17.12"
+
 "@babel/register@^7.0.0", "@babel/register@^7.12.1":
   version "7.17.7"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.17.7.tgz#5eef3e0f4afc07e25e847720e7b987ae33f08d0b"
@@ -1771,6 +1796,13 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@egjs/hammerjs@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
+  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -1904,6 +1936,23 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
+"@gorhom/bottom-sheet@^4":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.3.1.tgz#842790fd9f4c2470dc0682a1eb9616b68f93a71e"
+  integrity sha512-z7Mlo8GOqGAZsPJXL17v3o+I1TQBPZ+n+FmZybBCoM73m/aYXLCtpXo/knoPaZkI91eKuWQ3LLz+yCfGkNPiuA==
+  dependencies:
+    "@gorhom/portal" "1.0.13"
+    invariant "^2.2.4"
+    nanoid "^3.3.3"
+    react-native-redash "^16.1.1"
+
+"@gorhom/portal@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-1.0.13.tgz#da3af4d427e1fa68d264107de4b3072a4adf35ce"
+  integrity sha512-ViClKPkyGnj8HVMW45OGQSnGbWBVh8i3tgMOkGqpm6Cv0WVcDfUL7SER6zyGQy8Wdoj3GUDpAJFMqVOxpmRpzw==
+  dependencies:
+    nanoid "^3.3.1"
 
 "@hapi/hoek@^9.0.0":
   version "9.2.1"
@@ -3863,6 +3912,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hammerjs@^2.0.36":
+  version "2.0.41"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
+  integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
@@ -3882,6 +3936,11 @@
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
   integrity sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==
+
+"@types/invariant@^2.2.35":
+  version "2.2.35"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.35.tgz#cd3ebf581a6557452735688d8daba6cf0bd5a3be"
+  integrity sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg==
 
 "@types/is-function@^1.0.0":
   version "1.0.1"
@@ -4540,6 +4599,11 @@ abort-controller@^3.0.0:
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
   dependencies:
     event-target-shim "^5.0.0"
+
+abs-svg-path@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"
+  integrity sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==
 
 absolute-path@^0.0.0:
   version "0.0.0"
@@ -10136,6 +10200,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -10880,6 +10949,11 @@ nanoid@^3.1.23, nanoid@^3.1.30, nanoid@^3.3.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
   integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
+nanoid@^3.3.3:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -11065,6 +11139,13 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+
+normalize-svg-path@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz#0e614eca23c39f0cffe821d6be6cd17e569a766c"
+  integrity sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==
+  dependencies:
+    svg-arc-to-cubic-bezier "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -11537,6 +11618,11 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-svg-path@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/parse-svg-path/-/parse-svg-path-0.1.2.tgz#7a7ec0d1eb06fa5325c7d3e009b859a09b5d49eb"
+  integrity sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==
 
 parse5@6.0.1, parse5@^6.0.0:
   version "6.0.1"
@@ -12243,10 +12329,43 @@ react-native-codegen@^0.0.8:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
+react-native-gesture-handler@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.4.2.tgz#de93760b0bc251d94e8ae692f9850ec3ed2e4f27"
+  integrity sha512-K3oMiQV7NOVB5RvNlxkyJxU1Gn6m1cYu53MoFA542FVDSTR491d1eQkWDdqy4lW52rfF7IK7eE1LCi+kTJx7jw==
+  dependencies:
+    "@egjs/hammerjs" "^2.0.17"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+
 react-native-pager-view@^5.4.17:
   version "5.4.17"
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.17.tgz#aaccf6da6b64b7cb6ad9ed51426a561187bbca7f"
   integrity sha512-5ldX9YtIWaJoT2Tg+l4p4f+Juzdgn5PjVLfWb02wS+AsQ/cssQUsYqpTzuN+W91Ata0pSVhjaLvZnYjblUQmgw==
+
+react-native-reanimated@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.8.0.tgz#93c06ca84d91fb3865110b0857c49a24e316130e"
+  integrity sha512-kJvf/UWLBMaGCs9X66MKq5zdFMgwx8D0nHnolbHR7s8ZnbLdb7TlQ/yuzIXqn/9wABfnwtNRI3CyaP1aHWMmZg==
+  dependencies:
+    "@babel/plugin-transform-object-assign" "^7.16.7"
+    "@babel/preset-typescript" "^7.16.7"
+    "@types/invariant" "^2.2.35"
+    invariant "^2.2.4"
+    lodash.isequal "^4.5.0"
+    setimmediate "^1.0.5"
+    string-hash-64 "^1.0.3"
+
+react-native-redash@^16.1.1:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-redash/-/react-native-redash-16.3.0.tgz#a9112ff1b0e0b506a2e2ae50967597e73b69d343"
+  integrity sha512-dhmeYbQ/usGzxZSGZmzmRuIFF2LrtJUKqgseKgf9Jdj0JQ7VM20m/LqTg60+wjxeiyAh2D/vKsQ2U7rMkuoplQ==
+  dependencies:
+    abs-svg-path "^0.1.1"
+    normalize-svg-path "^1.0.1"
+    parse-svg-path "^0.1.2"
 
 react-native-safe-area-context@^4.2.5:
   version "4.2.5"
@@ -13429,6 +13548,11 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
+string-hash-64@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
+  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -13646,6 +13770,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+svg-arc-to-cubic-bezier@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz#390c450035ae1c4a0104d90650304c3bc814abe6"
+  integrity sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==
 
 svg-parser@^2.0.2:
   version "2.0.4"


### PR DESCRIPTION
## Related issue
- \#22

## Description
- 드롭다운 컴포넌트 구현 (드롭다운 + 바텀시트)
- 드롭다운
  -  드롭다운 아이콘 클릭 시 바텀시트 노출
  - 바텀 시트의 ref를 컨트롤하는 함수 사용  (onPress 함수에 전달)
- 바텀시트
  - 바텀 탭보다 아래에서 출력될 수 있는 바텀시트 모달 사용
  - 내부 컨텐츠는 flatList로 제공   
## Changes detail
- react-native-animated, react-native-gesture-handler,  @gohrom/bottom-sheet 라이브러리 추가
  -  react-native-animated, react-native-gesture-handler : 바텀시트의 움직임이나 시각 효과에 필요
  - @gohrom/bottom-sheet:  바텀시트를 제공하는 라이브러리 
- AreaDropDown 컴포넌트 : 회원가입에 필요한 정보 제공 컴포넌트, 바텀시트의 ref를 통해 호출
- MyBottomSheet 컴포넌트 : React.forwardRef 를 통해 자식의 ref를 부모가 사용할 수 있도록 함
- App.tsx 파일  BottomSheetModalProvider로 감쌈: 앱 전체에서 사용할 수 있음