### PR TITLE
fix: fix android configuration for .env

### DIFF
--- a/packages/climbingapp/android/app/build.gradle
+++ b/packages/climbingapp/android/app/build.gradle
@@ -134,7 +134,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        resValue "string", "build_config_package", "climbingapp_IN_ANDROIDMANIFEST_XML"
+        resValue "string", "build_config_package", "com.climbingapp"
         applicationId "com.climbingapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/packages/climbingapp/ios/climbingApp.xcodeproj/project.pbxproj
+++ b/packages/climbingapp/ios/climbingApp.xcodeproj/project.pbxproj
@@ -584,6 +584,7 @@
 		};
 		83CBBA211A601CBA00E9B192 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 78E803E4287BD9EE00AB9FB7 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/packages/climbingapp/ios/climbingApp.xcodeproj/xcshareddata/xcschemes/climbingApp.xcscheme
+++ b/packages/climbingapp/ios/climbingApp.xcodeproj/xcshareddata/xcschemes/climbingApp.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
+               scriptText = "&quot;${SRCROOT}/../../../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
## Related issue
Fixes #67 

## Description
- android runtime 때 Config 파일을 가지고 오지 못하는 이슈 해결
- build.gradle (app) 의 defaultConfig 의 패키지네임 입력 오류 해결 
- ios의 build pre-action 파일 경로 변경 (모노레포 이슈)

## Changes detail
- xcode => 상단 product => scheme => edit scheme => build => pre-actions =>. path를 모노레포에 맞게 (../..) 2 개 더 전으로 이동
- defaultConfig의 resValue로 등록한 속성 => 패키지 이름 필요 => com.climbingapp 으로 제대로 입력 후 정상 동작