### PR TITLE
feat: implement input and dropdown component for web

### DIFF
--- a/packages/climbingweb/src/components/common/DropDown/index.stories.tsx
+++ b/packages/climbingweb/src/components/common/DropDown/index.stories.tsx
@@ -1,0 +1,8 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { DropDown } from '.';
+export default {
+    title: 'WEB/DropDown',
+    component: DropDown,
+} as ComponentMeta<typeof DropDown>;
+
+export const Primary: ComponentStory<typeof DropDown> = () => <DropDown />;

--- a/packages/climbingweb/src/components/common/DropDown/index.tsx
+++ b/packages/climbingweb/src/components/common/DropDown/index.tsx
@@ -1,0 +1,21 @@
+import { ChangeEvent, useState } from 'react';
+import ArrowDown from 'climbingweb/src/assets/icon/ic_20_arrow_down_gray400.svg';
+import Image from 'next/image';
+
+interface DropDownProps {
+    onSheetOpen?: ({ }: any) => void;
+}
+
+export const DropDown = ({ onSheetOpen }: DropDownProps) => {
+    const [value, setValue] = useState('');
+    const handleChangeValue = (e: ChangeEvent<HTMLInputElement>) => {
+        setValue(e.target.value);
+    };
+
+    return (
+        <div className='border-2 border-gray-300 h-12 w-full bg-white rounded-lg relative flex flex-row items-center justify-between px-4'>
+            <input value={value} disabled onChange={e => handleChangeValue(e)} className='h-full w-full outline-0 disabled:bg-white' />
+            <Image src={ArrowDown} onClick={onSheetOpen} alt='arrow_down' />
+        </div>
+    );
+};

--- a/packages/climbingweb/src/components/common/Input/StringCount.tsx
+++ b/packages/climbingweb/src/components/common/Input/StringCount.tsx
@@ -1,0 +1,13 @@
+
+
+interface CountProps {
+    maxCount: number;
+    count: number;
+}
+
+export const StringCount = ({ maxCount, count }: CountProps) => {
+
+    return (
+        <p className='text-gray-300'>{count + '/' + maxCount}</p>
+    );
+};

--- a/packages/climbingweb/src/components/common/Input/index.stories.tsx
+++ b/packages/climbingweb/src/components/common/Input/index.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Input } from '.';
+import { StringCount } from './StringCount';
+
+export default {
+    title: 'WEB/Input',
+    component: Input,
+} as ComponentMeta<typeof Input>;
+
+export const Primary: ComponentStory<typeof Input> = () => <Input rightNode={<StringCount maxCount={20} count={0} />} />;

--- a/packages/climbingweb/src/components/common/Input/index.tsx
+++ b/packages/climbingweb/src/components/common/Input/index.tsx
@@ -1,0 +1,33 @@
+import { ChangeEvent, useRef, useState, useEffect } from 'react';
+
+
+interface InputProps {
+    rightNode?: JSX.Element;
+}
+
+export const Input = ({ rightNode }: InputProps) => {
+    const ref = useRef(null);
+    const [borderColor, setBorderColor] = useState('');
+    const [value, setValue] = useState('');
+    const containerCss = `border-2 border-gray-300 h-12 w-full bg-white rounded-lg relative flex flex-row items-center justify-between px-4 focused:border-purple-500 ${borderColor}`;
+    const handleFocused = () => {
+        setBorderColor('border-purple-500');
+    };
+    const handleFocusedOut = () => {
+        setBorderColor('');
+    };
+    const handleChangeValue = (e: ChangeEvent<HTMLInputElement>) => {
+        setValue(e.target.value);
+
+    };
+    useEffect(() => {
+        console.log(value);
+    }, [value]);
+
+    return (
+        <div className={containerCss}>
+            <input ref={ref} value={value} onChange={e => handleChangeValue(e)} onFocus={handleFocused} onBlur={handleFocusedOut} className='h-full w-full outline-0' />
+            {rightNode}
+        </div>
+    );
+};


### PR DESCRIPTION
## Related issue
Fixes #92 
Fixes #93 

## Description
- Input 컴포넌트 뷰 구현  
- drop down 컴포넌트  뷰 구현

## Changes detail
-  input 컴포넌트
  - props (rightnode)   =>  컴포넌트 ui 내부에 노드 추가 가능
- dropdown
  - 현재 뷰만 존재,  bottomsheet와 연동해 사용 
