### PR TITLE
feat: 페이지 별 바텀시트 적용

### DIFF
--- a/packages/climbingweb/pages/_app.tsx
+++ b/packages/climbingweb/pages/_app.tsx
@@ -1,7 +1,6 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import React from 'react';
-import { ThemeProvider } from 'next-themes';
 import store from '../src/store';
 import { Provider } from 'react-redux';
 import NavBar from 'climbingweb/src/components/common/bottomNav/NavBar';
@@ -10,10 +9,8 @@ import navButtons from 'climbingweb/src/components/common/bottomNav/button';
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <Provider store={store}>
-      <ThemeProvider attribute="class">
-        <Component {...pageProps} />
-        <NavBar navButtons={navButtons} />
-      </ThemeProvider>
+      <Component {...pageProps} />
+      <NavBar navButtons={navButtons} />
     </Provider>
   );
 }

--- a/packages/climbingweb/pages/center/[cid].tsx
+++ b/packages/climbingweb/pages/center/[cid].tsx
@@ -1,25 +1,37 @@
 import { CenterInfoContent } from 'climbingweb/src/components/CenterInfo/CenterInfoContent';
 import { CenterInfoHead } from 'climbingweb/src/components/CenterInfo/CenterInfoHead';
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
-import { AppLogo, BookMarkButton, OptionButton } from 'climbingweb/src/components/common/IconButton';
+import {
+  AppLogo,
+  BookMarkButton,
+  OptionButton,
+} from 'climbingweb/src/components/common/IconButton';
 
 interface DetailPageProps {
-    title: string;
+  title: string;
 }
 
-const img = 'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80';
+const img =
+  'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80';
 const list = [img, img, img, img, img, img, img, img];
 
 export default function CenterDetailPage({ title }: DetailPageProps) {
-    title = '더클라이밍 마곡';
-    return (
-        <section className='mb-footer overflow-auto scrollbar-hide'>
-            <AppBar
-                leftNode={<AppLogo />}
-                rightNode={<div className='flex flex-row gap-x-3'><BookMarkButton /> <OptionButton /></div>}
-            />
-            <CenterInfoHead title={title} address='서울특별시 강서구 마곡동 796-3 마곡사이언스타워 7층' />
-            <CenterInfoContent imageList={list} />
-        </section>
-    );
+  title = '더클라이밍 마곡';
+  return (
+    <section className="mb-footer overflow-auto scrollbar-hide">
+      <AppBar
+        leftNode={<AppLogo />}
+        rightNode={
+          <div className="flex flex-row gap-x-3">
+            <BookMarkButton /> <OptionButton />
+          </div>
+        }
+      />
+      <CenterInfoHead
+        title={title}
+        address="서울특별시 강서구 마곡동 796-3 마곡사이언스타워 7층"
+      />
+      <CenterInfoContent imageList={list} />
+    </section>
+  );
 }

--- a/packages/climbingweb/pages/center/request/index.tsx
+++ b/packages/climbingweb/pages/center/request/index.tsx
@@ -35,7 +35,10 @@ export default function ReportPage({}) {
       <div className="px-5 flex flex-col gap-4">
         <div className="flex flex-col gap-2.5">
           <h2 className="text-lg font-extrabold leading-6">요청 부분</h2>
-          <DropDown onSheetOpen={handleOpen} />
+          <DropDown
+            onSheetOpen={handleOpen}
+            placeholder="요청 부분을 선택해주세요"
+          />
         </div>
         <div className="flex flex-col gap-2.5">
           <h2 className="text-lg font-extrabold leading-6">요청 내용</h2>

--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -7,13 +7,29 @@ import {
   AppLogo,
 } from 'climbingweb/src/components/common/IconButton';
 import { useRouter } from 'next/router';
-
+import { BottomSheet } from 'react-spring-bottom-sheet';
+import { useState } from 'react';
+import 'react-spring-bottom-sheet/dist/style.css';
+import { FeedEditSheet } from 'climbingweb/src/components/common/BottomSheetContents/FeedEditSheet';
 interface Feed {
   imageList: string[];
   holdList: Hold[];
 }
 
 const Home: NextPage = () => {
+  const [openSheet, setOpenSheet] = useState<boolean>(false);
+  const handleCancelDeleteSheet = () => {
+    setOpenSheet(false);
+  };
+
+  const handleConfirmDeleteSheet = () => {
+    setOpenSheet(true);
+  };
+
+  const onEdit = () => {
+    setOpenSheet(true);
+  };
+
   const TestimageList = [''];
   const TestholdList: Hold[] = [{ url: '', count: 1 }];
 
@@ -35,8 +51,19 @@ const Home: NextPage = () => {
         rightNode={<ModifiedButton onClick={onCreateFeed} />}
       />
       {FeedList?.map(({ imageList, holdList }, idx) => (
-        <HomeFeed key={`key${idx}`} imageList={imageList} holdList={holdList} />
+        <HomeFeed
+          key={`key${idx}`}
+          imageList={imageList}
+          holdList={holdList}
+          onEdit={onEdit}
+        />
       ))}
+      <BottomSheet open={openSheet}>
+        <FeedEditSheet
+          onCancel={handleCancelDeleteSheet}
+          onConfirm={handleConfirmDeleteSheet}
+        />
+      </BottomSheet>
     </div>
   );
 };

--- a/packages/climbingweb/pages/report/index.tsx
+++ b/packages/climbingweb/pages/report/index.tsx
@@ -27,7 +27,10 @@ export default function ReportPage({}) {
       <div className="px-5 flex flex-col gap-4">
         <div className="flex flex-col gap-2.5">
           <h2 className="text-lg font-extrabold leading-6">신고 사유</h2>
-          <DropDown onSheetOpen={handleOpen} />
+          <DropDown
+            onSheetOpen={handleOpen}
+            placeholder="신고 사유를 선택해주세요"
+          />
         </div>
         <div className="flex flex-col gap-2.5">
           <h2 className="text-lg font-extrabold leading-6">신고 내용</h2>

--- a/packages/climbingweb/pages/search/index.tsx
+++ b/packages/climbingweb/pages/search/index.tsx
@@ -1,6 +1,7 @@
 import CenterResult from 'climbingweb/src/components/common/CenterResult/CenterResult';
 import RaonResult from 'climbingweb/src/components/SearchResult/RaonResult/RaonResult';
 import SearchBar from 'climbingweb/src/components/SearchResult/SearchBar/SearchBar';
+import { useBTSheet } from 'climbingweb/src/hooks/useBtSheet';
 import React, { useEffect } from 'react';
 import { useState } from 'react';
 
@@ -29,6 +30,7 @@ const raonListExample = [
 ];
 
 const SearchPage = () => {
+  const { renderSheet } = useBTSheet();
   const [centerList, setCenterList] = useState<Center[]>([]);
   const [raonList, setRaonList] = useState<Raon[]>([]);
   useEffect(() => {
@@ -61,6 +63,7 @@ const SearchPage = () => {
           ))}
         </div>
       </div>
+      {renderSheet()}
     </div>
   );
 };

--- a/packages/climbingweb/pages/setting/index.tsx
+++ b/packages/climbingweb/pages/setting/index.tsx
@@ -8,6 +8,8 @@ import { VersionInfo } from 'climbingweb/src/components/SettingInfo/VersionInfo'
 import { SettingList } from 'climbingweb/src/components/SettingInfo/SettingList';
 import { EditMyInfo } from 'climbingweb/src/components/SettingInfo/EditMyInfo';
 import { NotificationList } from 'climbingweb/src/components/SettingInfo/Notification/NotificationList';
+import { BottomSheet } from 'react-spring-bottom-sheet';
+import { LeaveSheet } from 'climbingweb/src/components/common/BottomSheetContents/LeaveSheet';
 
 export default function SettingPage() {
   const titleList: string[] = [
@@ -23,7 +25,19 @@ export default function SettingPage() {
   ];
   const defaultTitle = '설정';
   const [titleName, setTitleName] = useState<string>(defaultTitle);
+  const [sheetKey, setSheetKey] = useState<string>();
+  const [openSheet, setOpenSheet] = useState<boolean>(false);
   const handleClick = (choice: string) => {
+    if (choice === '로그아웃') {
+      setSheetKey('logout');
+      setOpenSheet(true);
+      return;
+    }
+    if (choice === '탈퇴하기') {
+      setSheetKey('leave');
+      setOpenSheet(true);
+      return;
+    }
     if (choice !== 'titleName') setTitleName(choice);
   };
   const handleGoToBack = () => {
@@ -37,6 +51,10 @@ export default function SettingPage() {
       '클라온 앱 공지사항 입니다. 확인을 해주세요~ 전기통신사업법 제22조 5 제1항에 따라 불법촬영물등의 유통방지 및 이용자보호를 위한 다음의 기술적, 관리적 조치가 시행될 에정임을 안내 드립니다.',
   };
   const notiList = [testNoti, testNoti, testNoti];
+
+  const onDismiss = () => {
+    setOpenSheet(false);
+  };
 
   return (
     <div className="h-screen flex flex-col">
@@ -60,6 +78,17 @@ export default function SettingPage() {
         {titleName === '이용 약관' && <>이용 약관</>}
         {titleName === '개인정보 처리 방침' && <>개인정보 처리 방침</>}
       </div>
+      <BottomSheet open={openSheet} onDismiss={onDismiss}>
+        <LeaveSheet
+          text={
+            sheetKey === 'leave'
+              ? 'CLAON에서 하강하시겠습니까?'
+              : sheetKey === 'logout'
+              ? '로그아웃 하시겠습니까?'
+              : ''
+          }
+        />
+      </BottomSheet>
     </div>
   );
 }

--- a/packages/climbingweb/src/components/HomeFeed/FeedHeader/FeedHeader.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/FeedHeader/FeedHeader.tsx
@@ -7,10 +7,12 @@ const FeedHeader = ({
   userImage,
   userName,
   userLocation,
+  onEdit,
 }: {
   userImage: string | null | undefined;
   userName: string;
   userLocation: string;
+  onEdit: ({}: any) => void;
 }) => {
   return (
     <header className={'flex w-full h-[56px] my-1 justify-between'}>
@@ -26,7 +28,7 @@ const FeedHeader = ({
         </div>
       </div>
       <button className={'w-[24px] h-[24px] self-center'}>
-        <Image src={optionDotImg} alt="..." />
+        <Image src={optionDotImg} alt="..." onTouchEnd={onEdit} />
       </button>
     </header>
   );

--- a/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
@@ -9,9 +9,11 @@ import ImageSlider from '../ImageSlider/ImageSlider';
 const HomeFeed = ({
   imageList,
   holdList,
+  onEdit,
 }: {
   imageList: string[];
   holdList: Hold[];
+  onEdit: ({}: any) => void;
 }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
@@ -65,6 +67,7 @@ const HomeFeed = ({
         userImage={null}
         userName="kimclaon85"
         userLocation="비블럭 클라이밍 강남점"
+        onEdit={onEdit}
       />
       <ImageSlider
         imageList={imageList}

--- a/packages/climbingweb/src/components/SettingInfo/EditMyInfo.tsx
+++ b/packages/climbingweb/src/components/SettingInfo/EditMyInfo.tsx
@@ -79,6 +79,7 @@ export const EditMyInfo = ({ instagramId }: InfoProps) => {
       </div>
       {/*bottomSheet  */}
       <BottomSheet
+        className=" z-[60]"
         open={sheetOpen}
         onDismiss={onDismiss}
         defaultSnap={({ maxHeight }) => maxHeight}

--- a/packages/climbingweb/src/components/common/BottomSheetContents/FeedEditSheet.tsx
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/FeedEditSheet.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { LeaveSheet } from './LeaveSheet';
+import { ListSheet } from './ListSheet/ListSheet';
+import { ConfirmSheetProps } from './type';
+
+export const FeedEditSheet = ({ onCancel, onConfirm }: ConfirmSheetProps) => {
+  const [selectDelete, setSelectDelete] = useState<boolean>(false);
+  const handleAlertDelete = (e: any) => {
+    const target = e.target.innerHTML;
+    if (target === '삭제하기') setSelectDelete(true);
+  };
+  console.log(selectDelete);
+  useEffect(() => {
+    setSelectDelete(false);
+  }, []);
+
+  const sheetList = ['삭제하기', '수정하기'];
+  return (
+    <>
+      {selectDelete ? (
+        <LeaveSheet
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+          text="게시글을 삭제하시겠습니까?"
+        />
+      ) : (
+        <ListSheet
+          headerTitle=""
+          onSelect={handleAlertDelete}
+          list={sheetList}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/climbingweb/src/components/common/BottomSheetContents/LeaveSheet.tsx
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/LeaveSheet.tsx
@@ -1,20 +1,18 @@
+import { NormalButton, WhiteButton } from '../button/Button';
+import { ConfirmSheetProps } from './type';
 
-
-
-interface ButtonProps {
-    onClick: ({ }: any) => void;
-}
-
-export const LeaveSheet = ({ onClick }: ButtonProps) => {
-
-    return (
-        <div className='flex flex-col gap-6 mb-4'>
-            <p className='text-sm text-gray-600 font-normal'>CLAON에서 하강 하시겠습니까?</p>
-            <div className='flex flex-row justify-center text-center text-base font-bold'>
-                <p className='w-6/12'>아니오</p>
-                <p className='text-gray-300'> | </p>
-                <p className='w-6/12' onClick={onClick}> 예</p>
-            </div>
-        </div>
-    );
+export const LeaveSheet = ({
+  onConfirm,
+  onCancel,
+  text,
+}: ConfirmSheetProps) => {
+  return (
+    <div className="flex flex-col gap-6 mb-4 p-4">
+      <p className="text-base text-gray-600 font-normal text-center">{text}</p>
+      <div className="flex flex-row justify-center text-center text-base font-bold px-4 gap-4">
+        <WhiteButton onClick={onCancel}>취소</WhiteButton>
+        <NormalButton onClick={onConfirm}>확인</NormalButton>
+      </div>
+    </div>
+  );
 };

--- a/packages/climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet.tsx
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet.tsx
@@ -1,17 +1,15 @@
+import { ListSheetProps } from '../type';
 import { SheetHeader } from './SheetHeader';
 
-interface SheetProps {
-  headerTitle: string;
-  list: string[];
-}
-
-export const ListSheet = ({ headerTitle, list }: SheetProps) => {
+export const ListSheet = ({ headerTitle, list, onSelect }: ListSheetProps) => {
   return (
     <div className="flex flex-col p-4 gap-6">
       <SheetHeader headerTitle={headerTitle} />
       <div className="flex flex-col gap-6 text-black">
         {list?.map((area) => (
-          <p key={`areaKey${area}`}>{area}</p>
+          <p onTouchEnd={onSelect} key={`areaKey${area}`}>
+            {area}
+          </p>
         ))}
       </div>
     </div>

--- a/packages/climbingweb/src/components/common/BottomSheetContents/type.d.ts
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/type.d.ts
@@ -1,0 +1,11 @@
+export interface ListSheetProps {
+  headerTitle: string;
+  list: string[];
+  onSelect?: ({}: any) => void;
+}
+
+export interface ConfirmSheetProps {
+  onConfirm?: ({}: any) => void;
+  onCancel?: ({}: any) => void;
+  text?: string;
+}

--- a/packages/climbingweb/src/components/common/DropDown/index.tsx
+++ b/packages/climbingweb/src/components/common/DropDown/index.tsx
@@ -4,9 +4,10 @@ import Image from 'next/image';
 
 interface DropDownProps {
   onSheetOpen?: ({}: any) => void;
+  placeholder?: string;
 }
 
-export const DropDown = ({ onSheetOpen }: DropDownProps) => {
+export const DropDown = ({ onSheetOpen, placeholder }: DropDownProps) => {
   const [value, setValue] = useState('');
   const handleChangeValue = (e: ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -19,6 +20,7 @@ export const DropDown = ({ onSheetOpen }: DropDownProps) => {
         disabled
         onChange={(e) => handleChangeValue(e)}
         className="h-full w-full outline-0 disabled:bg-white"
+        placeholder={placeholder}
       />
       <Image src={ArrowDown} onClick={onSheetOpen} alt="arrow_down" />
     </div>

--- a/packages/climbingweb/src/components/common/IconButton.tsx
+++ b/packages/climbingweb/src/components/common/IconButton.tsx
@@ -8,37 +8,43 @@ import BookMarkYellow from 'climbingweb/src/assets/icon/ic_24_bookmark_yellow.sv
 import Option from 'climbingweb/src/assets/icon/ic_24_option_gray800.svg';
 
 interface ButtonProps {
-    onClick?: ({ }: any) => void;
+  onClick?: ({}: any) => void;
 }
 
 interface BookMark extends ButtonProps {
-    isBookMarked?: boolean;
+  isBookMarked?: boolean;
 }
 
 export const BackButton = ({ onClick }: ButtonProps) => {
-    return < Image src={ArrowBack} onClick={onClick} alt="back" />;
+  return <Image src={ArrowBack} onClick={onClick} alt="back" />;
 };
 
 export const ModifiedButton = ({ onClick }: ButtonProps) => {
-    return < Image src={Pencil} onClick={onClick} alt="modified" />;
+  return <Image src={Pencil} onClick={onClick} alt="modified" />;
 };
 
 export const AppLogo = ({ onClick }: ButtonProps) => {
-    return < Image src={Logo} onClick={onClick} alt="logo" />;
+  return <Image src={Logo} onClick={onClick} alt="logo" />;
 };
 
 export const SettingButton = ({ onClick }: ButtonProps) => {
-    return < Image src={Setting} onClick={onClick} alt="setting" />;
+  return <Image src={Setting} onClick={onClick} alt="setting" />;
 };
 
 export const BookMarkButton = ({ onClick, isBookMarked }: BookMark) => {
-    return < Image src={isBookMarked ? BookMarkYellow : BookMarkWhite} onClick={onClick} alt="bookmark" />;
+  return (
+    <Image
+      src={isBookMarked ? BookMarkYellow : BookMarkWhite}
+      onClick={onClick}
+      alt="bookmark"
+    />
+  );
 };
 
 export const OptionButton = ({ onClick }: ButtonProps) => {
-    return < Image src={Option} onClick={onClick} alt="option" />;
+  return <Image src={Option} onClick={onClick} alt="option" />;
 };
 
 export const Empty = () => {
-    return <div className='w-6 h-6' />;
+  return <div className="w-6 h-6" />;
 };

--- a/packages/climbingweb/src/components/common/bottomNav/NavBar.tsx
+++ b/packages/climbingweb/src/components/common/bottomNav/NavBar.tsx
@@ -2,20 +2,19 @@ import NavButton from './NavButton';
 import { ButtonProps, NavProps } from './type';
 
 const NavBar = ({ navButtons }: NavProps) => {
-
-    return (
-        <div className="flex flex-row w-full h-footer justify-between py-4 px-10 border-t bottom-0 fixed bg-white z-50">
-            {navButtons.map(({ path, icon, activedIcon, label }: ButtonProps) => (
-                <NavButton
-                    key={path}
-                    path={path}
-                    label={label}
-                    icon={icon}
-                    activedIcon={activedIcon}
-                />
-            ))}
-        </div>
-    );
+  return (
+    <div className="flex flex-row w-full h-footer justify-between py-4 px-10 border-t bottom-0 fixed bg-white">
+      {navButtons.map(({ path, icon, activedIcon, label }: ButtonProps) => (
+        <NavButton
+          key={path}
+          path={path}
+          label={label}
+          icon={icon}
+          activedIcon={activedIcon}
+        />
+      ))}
+    </div>
+  );
 };
 
 export default NavBar;

--- a/packages/climbingweb/src/components/common/button/Button.tsx
+++ b/packages/climbingweb/src/components/common/button/Button.tsx
@@ -4,11 +4,34 @@ interface ButtonProps {
 }
 
 export const NormalButton = ({ onClick, children }: ButtonProps) => {
-    return <button className='w-full bg-purple-500 rounded-lg w-30 h-12 text-white' onClick={onClick}>{children}</button>;
+  return (
+    <button
+      className="w-full bg-purple-500 rounded-lg w-30 h-12 text-white active:bg-purple-400"
+      onTouchEnd={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const WhiteButton = ({ onClick, children }: ButtonProps) => {
+  return (
+    <button
+      className="w-full bg-gray-100 rounded-lg w-30 h-12 text-black active:bg-gray-200"
+      onTouchEnd={onClick}
+    >
+      {children}
+    </button>
+  );
 };
 
 export const SmmallNodeButton = ({ onClick, children }: ButtonProps) => {
-    return (
-        <button onClick={onClick} className=' w-10 h-6 bg-white border border-gray-300 rounded-lg text-xs'>{children}</button>
-    );
+  return (
+    <button
+      onTouchEnd={onClick}
+      className=" w-10 h-6 bg-white border border-gray-300 rounded-lg text-xs"
+    >
+      {children}
+    </button>
+  );
 };

--- a/packages/climbingweb/src/hooks/useBtSheet.tsx
+++ b/packages/climbingweb/src/hooks/useBtSheet.tsx
@@ -1,0 +1,40 @@
+import {
+  ActionCreatorWithOptionalPayload,
+  ActionCreatorWithoutPayload,
+} from '@reduxjs/toolkit';
+import { ReactNode } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { BottomSheet } from 'react-spring-bottom-sheet';
+import { bindActionCreators } from 'redux';
+import { RootState } from '../store/slices';
+import { openBTSheet, closeBTSheet, setSheet } from '../store/slices/uiSlice';
+
+const useBTSheetActions = () => {
+  const dispatch = useDispatch();
+  return bindActionCreators({ openBTSheet, closeBTSheet, setSheet }, dispatch);
+};
+
+type UseBTSheetResult = {
+  isOpen: boolean;
+  openBTS: ActionCreatorWithoutPayload<string>;
+  closeBTS: ActionCreatorWithoutPayload<string>;
+  setBTS: ActionCreatorWithOptionalPayload<ReactNode | ReactNode[], string>;
+  renderSheet: () => JSX.Element;
+};
+
+export const useBTSheet = (): UseBTSheetResult => {
+  const { open: isOpen, sheet } = useSelector(
+    (state: RootState) => state.ui.btSheet
+  );
+  const {
+    openBTSheet: openBTS,
+    closeBTSheet: closeBTS,
+    setSheet: setBTS,
+  } = useBTSheetActions();
+
+  const renderSheet = () => {
+    return <BottomSheet open={isOpen}>{sheet}</BottomSheet>;
+  };
+
+  return { isOpen, openBTS, closeBTS, setBTS, renderSheet };
+};

--- a/packages/climbingweb/src/hooks/useBtSheet.tsx
+++ b/packages/climbingweb/src/hooks/useBtSheet.tsx
@@ -33,7 +33,11 @@ export const useBTSheet = (): UseBTSheetResult => {
   } = useBTSheetActions();
 
   const renderSheet = () => {
-    return <BottomSheet open={isOpen}>{sheet}</BottomSheet>;
+    return (
+      <BottomSheet open={isOpen} onDismiss={closeBTS}>
+        {sheet}
+      </BottomSheet>
+    );
   };
 
   return { isOpen, openBTS, closeBTS, setBTS, renderSheet };

--- a/packages/climbingweb/src/store/index.ts
+++ b/packages/climbingweb/src/store/index.ts
@@ -1,9 +1,12 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import { useDispatch } from 'react-redux';
 import rootReducer from './slices';
 
 const store = configureStore({
   reducer: rootReducer,
+  middleware: getDefaultMiddleware({
+    serializableCheck: false,
+  }),
 });
 
 export type AppDispatch = typeof store.dispatch;

--- a/packages/climbingweb/src/store/slices/index.ts
+++ b/packages/climbingweb/src/store/slices/index.ts
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
-
-const rootReducer = combineReducers({});
+import ui from './uiSlice';
+const rootReducer = combineReducers({
+  ui,
+});
 
 export type RootState = ReturnType<typeof rootReducer>;
 

--- a/packages/climbingweb/src/store/slices/uiSlice.ts
+++ b/packages/climbingweb/src/store/slices/uiSlice.ts
@@ -31,6 +31,7 @@ const uiSlice = createSlice({
       action: PayloadAction<React.ReactNode[] | React.ReactNode | null>
     ) {
       state.btSheet.sheet = action.payload;
+      console.log(state.btSheet.sheet);
     },
   },
 });

--- a/packages/climbingweb/src/store/slices/uiSlice.ts
+++ b/packages/climbingweb/src/store/slices/uiSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface BtSheet {
+  open: boolean;
+  sheet?: React.ReactNode[] | React.ReactNode | null;
+}
+
+interface BtSheetState {
+  btSheet: BtSheet;
+}
+
+const initialState: BtSheetState = {
+  btSheet: {
+    open: false,
+    sheet: null,
+  },
+};
+
+const uiSlice = createSlice({
+  name: 'ui',
+  initialState,
+  reducers: {
+    openBTSheet(state) {
+      state.btSheet.open = true;
+    },
+    closeBTSheet(state) {
+      state.btSheet.open = false;
+    },
+    setSheet(
+      state,
+      action: PayloadAction<React.ReactNode[] | React.ReactNode | null>
+    ) {
+      state.btSheet.sheet = action.payload;
+    },
+  },
+});
+
+export default uiSlice.reducer;
+export const { openBTSheet, closeBTSheet, setSheet } = uiSlice.actions;

--- a/packages/climbingweb/tailwind.config.js
+++ b/packages/climbingweb/tailwind.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   mode: 'jit',
-  content: ['./pages/**/*.{js,ts,jsx,tsx}', './src/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  darkMode: 'class',
   theme: {
     extend: {
       animation: {
@@ -38,7 +42,7 @@ module.exports = {
         },
         yellow: {
           500: '#FFDE3B',
-        },
+        }
       },
       minWidth: {
         10: '2.5rem',
@@ -46,11 +50,8 @@ module.exports = {
         40: '10rem',
       },
       spacing: {
-        footer: '5rem',
+        'footer': '5rem',
       },
-    },
-    daisyui: {
-      themes: ['light', 'dark'],
     },
   },
   plugins: [

--- a/packages/climbingweb/tailwind.config.js
+++ b/packages/climbingweb/tailwind.config.js
@@ -1,10 +1,6 @@
 module.exports = {
   mode: 'jit',
-  content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
-  darkmode: 'class',
+  content: ['./pages/**/*.{js,ts,jsx,tsx}', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       animation: {
@@ -42,7 +38,7 @@ module.exports = {
         },
         yellow: {
           500: '#FFDE3B',
-        }
+        },
       },
       minWidth: {
         10: '2.5rem',
@@ -50,7 +46,7 @@ module.exports = {
         40: '10rem',
       },
       spacing: {
-        'footer': '5rem',
+        footer: '5rem',
       },
     },
     daisyui: {


### PR DESCRIPTION
## Related issue
Fixes #116 

## Description
- 각 페이지마다 사용되는 바텀시트, 상황 별 시트 구현 및 적용

## Changes detail
- 바텀시트 사용 페이지
  -  홈,  암장 (리뷰, 수정), 게시글 신고, 개인정보 수정, 설정 
- 시트 종류
  -  ListSheet :  헤더와 컨텐츠 리스트를 나열하는 시트
  -  LeaveSheet : 타이틀, 취소, 확인 버튼의 시트

