### PR TITLE
feat: 신고하기 백엔드 로직 추가

### DIFF
--- a/packages/climbingweb/pages/report/index.tsx
+++ b/packages/climbingweb/pages/report/index.tsx
@@ -10,16 +10,49 @@ import TextArea from 'climbingweb/src/components/common/TextArea/TextArea';
 import { useState } from 'react';
 import { BottomSheet } from 'react-spring-bottom-sheet';
 import 'react-spring-bottom-sheet/dist/style.css';
+import ReportData from 'climbingweb/src/interface/ReportData';
+import { useCreateReport } from 'climbingweb/src/hooks/queries/useCreateReport';
+
+const REPORT_LIST = ['부적절한 게시글', '부적절한 닉네임', '잘못된 암장 선택'];
+
 export default function ReportPage({}) {
   const [open, setOpen] = useState(false);
+  const [reportData, setReportData] = useState<ReportData>({
+    content: '',
+    postId: '',
+    reportType: '',
+  });
+
+  const { mutate, isSuccess, error } = useCreateReport(reportData);
+
+  //바텀 시트 open/ close handler
   const handleOpen = () => {
     setOpen(true);
   };
   const handleDismiss = () => {
     setOpen(false);
   };
-  const header = '신고 사유';
-  const reportList = ['부적절한 게시글', '부적절한 닉네임', '잘못된 암장 선택'];
+
+  //바텀 시트 선택 handler
+  const handleSheetSelect = (selectedData: string) => {
+    setReportData({ ...reportData, reportType: selectedData });
+    setOpen(false);
+  };
+
+  //신고 내용 input handler
+  const handleContentInput = (contentData: string) => {
+    setReportData({ ...reportData, content: contentData });
+  };
+
+  //완료 버튼 클릭 handler
+  const handlerSubmit = () => {
+    mutate();
+    if (isSuccess) {
+      alert('입력 완료 되었습니다.');
+    } else {
+      alert(error);
+    }
+  };
 
   return (
     <section className="mb-footer">
@@ -28,6 +61,7 @@ export default function ReportPage({}) {
         <div className="flex flex-col gap-2.5">
           <h2 className="text-lg font-extrabold leading-6">신고 사유</h2>
           <DropDown
+            value={reportData.reportType}
             onSheetOpen={handleOpen}
             placeholder="신고 사유를 선택해주세요"
           />
@@ -35,14 +69,24 @@ export default function ReportPage({}) {
         <div className="flex flex-col gap-2.5">
           <h2 className="text-lg font-extrabold leading-6">신고 내용</h2>
           <TextArea
-            setData={() => {}}
+            setData={handleContentInput}
             placeholder="요청 내용을 자세히 입력해주세요."
           />
         </div>
-        <NormalButton>완료</NormalButton>
+        <NormalButton
+          onClick={() => {
+            handlerSubmit();
+          }}
+        >
+          완료
+        </NormalButton>
       </div>
       <BottomSheet open={open} onDismiss={handleDismiss}>
-        <ListSheet headerTitle={header} list={reportList} />
+        <ListSheet
+          headerTitle={'신고 사유'}
+          list={REPORT_LIST}
+          onSelect={handleSheetSelect}
+        />
       </BottomSheet>
     </section>
   );

--- a/packages/climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet.tsx
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet.tsx
@@ -7,7 +7,7 @@ export const ListSheet = ({ headerTitle, list, onSelect }: ListSheetProps) => {
       <SheetHeader headerTitle={headerTitle} />
       <div className="flex flex-col gap-6 text-black">
         {list?.map((area) => (
-          <p onTouchEnd={onSelect} key={`areaKey${area}`}>
+          <p onTouchEnd={() => onSelect(area)} key={`areaKey${area}`}>
             {area}
           </p>
         ))}

--- a/packages/climbingweb/src/components/common/BottomSheetContents/type.d.ts
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/type.d.ts
@@ -1,7 +1,7 @@
 export interface ListSheetProps {
   headerTitle: string;
   list: string[];
-  onSelect?: ({}: any) => void;
+  onSelect: ({}: any) => void;
 }
 
 export interface ConfirmSheetProps {

--- a/packages/climbingweb/src/components/common/DropDown/index.tsx
+++ b/packages/climbingweb/src/components/common/DropDown/index.tsx
@@ -1,27 +1,28 @@
-import { ChangeEvent, useState } from 'react';
 import ArrowDown from 'climbingweb/src/assets/icon/ic_20_arrow_down_gray400.svg';
 
 interface DropDownProps {
+  value: string;
   onSheetOpen?: ({}: any) => void;
   placeholder?: string;
 }
 
-export const DropDown = ({ onSheetOpen, placeholder }: DropDownProps) => {
-  const [value, setValue] = useState('');
-  const handleChangeValue = (e: ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-  };
-
+export const DropDown = ({
+  value,
+  onSheetOpen,
+  placeholder,
+}: DropDownProps) => {
   return (
-    <div className="border-2 border-gray-300 h-12 w-full bg-white rounded-lg relative flex flex-row items-center justify-between px-4">
+    <div
+      className="border-2 border-gray-300 h-12 w-full bg-white rounded-lg relative flex flex-row items-center justify-between px-4"
+      onClick={onSheetOpen}
+    >
       <input
         value={value}
         disabled
-        onChange={(e) => handleChangeValue(e)}
         className="h-full w-full outline-0 disabled:bg-white"
         placeholder={placeholder}
       />
-      <ArrowDown onClick={onSheetOpen} alt="arrow_down" />
+      <ArrowDown alt="arrow_down" />
     </div>
   );
 };

--- a/packages/climbingweb/src/hooks/queries/useCreateReport.ts
+++ b/packages/climbingweb/src/hooks/queries/useCreateReport.ts
@@ -1,0 +1,21 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import ReportData from 'climbingweb/src/interface/ReportData';
+import axios from 'axios';
+
+const createReport = async (reportData: ReportData) => {
+  const { data } = await axios.post(
+    `/posts/${reportData.postId}/report`,
+    reportData
+  );
+  return data;
+};
+
+export const useCreateReport = (
+  reportData: ReportData,
+  options?: Omit<
+    UseMutationOptions<unknown, unknown, void, unknown>,
+    'mutationFn'
+  >
+) => {
+  return useMutation(() => createReport(reportData), options);
+};

--- a/packages/climbingweb/src/interface/ReportData.ts
+++ b/packages/climbingweb/src/interface/ReportData.ts
@@ -1,0 +1,5 @@
+export default interface ReportData {
+  content: string;
+  postId: string;
+  reportType: string;
+}


### PR DESCRIPTION
## Description
- feat: 신고하기 백엔드 로직 추가
- 먼저 올린 풀 리퀘스트 먼저 머지 부탁 드립니다.

## Changes detail

- report 페이지 리팩터링
const REPORT_LIST 따로 뺌, api 호출을 위한 커스텀 훅 사용
- listSheet 컴포넌트 기능 변경 
바텀시트 list 선택시 선택한 값을 핸들링 할 수 있도록 선택한 값을 props로 받은 함수에 넣음
- ListSheetProps 인터페이스 변경
onSelect props 를 필수로 받도록 변경
- DropDown 컴포넌트 변경
애로우 버튼 터치 시에만 바텀 시트가 생기는 것이 아닌, 전체 컴포넌트 터치 시 바텀 시트가 나타나도록 변경, value 값을 props로 받을 수 있도록 변경하여, 상위 컴포넌트의 value 값을 보여주기만 하도록 변경
- `/posts/${reportData.postId}/report` api hooks 추가
- `/posts/${reportData.postId}/report` api 관련 data 인터페이스 ReportData 추가

### Checklist

- [ ] Test case
- [ ] End of work
