### PR TITLE
feat: 암장 메인 화면 백엔드 로직 추가

### DIFF
--- a/packages/climbingweb/pages/center/index.tsx
+++ b/packages/climbingweb/pages/center/index.tsx
@@ -1,39 +1,70 @@
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
 import CenterResultList from 'climbingweb/src/components/common/CenterResult/CenterResultList';
-import { CenterProps } from 'climbingweb/src/components/common/CenterResult/type';
 import {
   AppLogo,
   Empty,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
+import { useGetCenterList } from 'climbingweb/src/hooks/queries/center-controller/useGetCenterList';
 
 export default function CenterPage({}) {
-  const centerListExample: CenterProps[] = [
-    { name: '더클라이밍 마곡', star: 4.5, id: '1' },
-    { name: '더클라이밍 홍대점', star: 4.5, id: '2' },
-    { name: '더클라이밍 홍대점', star: 4.5, id: '3' },
-    { name: '더클라이밍 홍대점', star: 4.5, id: '4' },
-    { name: '더클라이밍 홍대점', star: 4.5, id: '5' },
-    { name: '더클라이밍 홍대점', star: 4.5, id: '6' },
-    { name: '더클라이밍 홍대점', star: 4.5, id: '7' },
-  ];
-
-  const centerGroupTitleList = [
-    '새로운 세팅',
-    '즐겨찾는 암장',
-    '내 주변 암장',
-    '새로운 암장',
-  ];
+  //새로운 세팅 리스트 useQuery state
+  const {
+    isLoading: isNewSettingLoading,
+    data: newSettingData,
+    isError: isNewSettingError,
+    error: newSettingError,
+  } = useGetCenterList('new_setting');
+  //즐겨찾는 암장 리스트 useQuery state
+  const {
+    isLoading: isBookmarkLoading,
+    data: bookmarkData,
+    isError: isBookmarkError,
+    error: bookmarkError,
+  } = useGetCenterList('bookmark');
+  //새로운 암장 리스트 useQuery state
+  const {
+    isLoading: isNewlyRegisteredLoading,
+    data: newlyRegisteredData,
+    isError: isNewlyRegisteredError,
+    error: newlyRegisteredError,
+  } = useGetCenterList('newly_registered');
 
   return (
     <section className="mb-footer">
       <AppBar leftNode={<AppLogo />} title=" " rightNode={<Empty />} />
       <div className="pl-4 flex flex-col gap-6">
-        {centerGroupTitleList.map((title) => (
-          <div key={title} className="flex flex-col gap-4">
-            <h2 className="text-lg font-extrabold leading-6">{title}</h2>
-            <CenterResultList centerList={centerListExample} />
-          </div>
-        ))}
+        <div className="flex flex-col gap-4">
+          <h2 className="text-lg font-extrabold leading-6">{'새로운 세팅'}</h2>
+          {isNewSettingLoading ? (
+            <div>로딩 중</div>
+          ) : isNewSettingError ? (
+            <div>{newSettingError}</div>
+          ) : newSettingData ? (
+            <CenterResultList centerList={newSettingData.results} />
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-4">
+          <h2 className="text-lg font-extrabold leading-6">
+            {'즐겨찾는 암장'}
+          </h2>
+          {isBookmarkLoading ? (
+            <div>로딩 중</div>
+          ) : isBookmarkError ? (
+            <div>{bookmarkError}</div>
+          ) : bookmarkData ? (
+            <CenterResultList centerList={bookmarkData.results} />
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-4">
+          <h2 className="text-lg font-extrabold leading-6">{'새로운 암장'}</h2>
+          {isNewlyRegisteredLoading ? (
+            <div>로딩 중</div>
+          ) : isNewlyRegisteredError ? (
+            <div>{newlyRegisteredError}</div>
+          ) : newlyRegisteredData ? (
+            <CenterResultList centerList={newlyRegisteredData.results} />
+          ) : null}
+        </div>
       </div>
     </section>
   );

--- a/packages/climbingweb/src/components/common/CenterResult/CenterResultList.tsx
+++ b/packages/climbingweb/src/components/common/CenterResult/CenterResultList.tsx
@@ -1,15 +1,19 @@
 import CenterResult from './CenterResult';
-import { CenterListProps } from './type';
+import { CenterProps } from './CenterResult';
+
+interface CenterListProps {
+  centerList: CenterProps[];
+}
 
 const CenterResultList = ({ centerList }: CenterListProps) => {
   return (
     <div className="w-full flex flex-row gap-1 overflow-x-auto scrollbar-hide">
-      {centerList?.map(({ name, star, image, id }) => (
+      {centerList.map(({ id, name, thumbnailUrl, reviewRank }) => (
         <CenterResult
           key={name}
           name={name}
-          image={image}
-          star={star}
+          thumbnailUrl={thumbnailUrl}
+          reviewRank={reviewRank}
           id={id}
         />
       ))}

--- a/packages/climbingweb/src/hooks/queries/center-controller/useGetCenterList.ts
+++ b/packages/climbingweb/src/hooks/queries/center-controller/useGetCenterList.ts
@@ -1,0 +1,67 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import axios from 'axios';
+
+interface CenterPreview {
+  id: string;
+  name: string;
+  thumbnailUrl: string;
+  reviewRank: number;
+}
+
+interface CenterPreviewResponse {
+  nextPageNum: number;
+  previousPageNum: number;
+  results: CenterPreview[];
+  totalCount: number;
+}
+
+// getCenterList api option 의 enum 값 정의를 위한 상수
+const GET_CENTER_OPTION = {
+  BOOKMARK: 'bookmark',
+  NEW_SETTING: 'new_setting',
+  NEWLY_REGISTERED: 'newly_registered',
+} as const;
+
+// getCenterList api option 의 enum 값
+type GetCenterOption = typeof GET_CENTER_OPTION[keyof typeof GET_CENTER_OPTION];
+
+/**
+ * GET /centers api 의 query 함수
+ *
+ * @param option getCenterList api option 값
+ * @returns axiosResponse.data
+ */
+const getCenterList = async (option: GetCenterOption) => {
+  const { data } = await axios.get<CenterPreviewResponse>('/centers', {
+    params: {
+      option: option,
+    },
+  });
+  return data;
+};
+
+/**
+ * getCenterList api useQuery hooks
+ *
+ * @param option getCenterList api 의 option 값 (bookmark, new_setting, newly_registered)
+ * @param options useQuery 추가 옵션 값
+ * @returns useQuery return 값
+ */
+export const useGetCenterList = (
+  option: GetCenterOption,
+  options?: Omit<
+    UseQueryOptions<
+      CenterPreviewResponse,
+      unknown,
+      CenterPreviewResponse,
+      string[]
+    >,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery(['getCenterList', option], () => getCenterList(option), {
+    retry: 0,
+    enabled: !!option,
+    ...options,
+  });
+};


### PR DESCRIPTION
## Description
feat: 암장 메인 화면 백엔드 로직 추가

## Changes detail
- 암장 메인 화면 백엔드 로직 추가
- CenterResultList 컴포넌트 앞선 PR 에 맞게 props 변경
- GET /centers api 의 useQuery hooks 추가

### Checklist

- [ ] Test case
- [ ] End of work
