### PR TITLE
feat: 암장 상세 정보 전체 백엔드 로직 추가

### DIFF
--- a/packages/climbingweb/pages/center/[cid].tsx
+++ b/packages/climbingweb/pages/center/[cid].tsx
@@ -6,18 +6,28 @@ import {
   BookMarkButton,
   OptionButton,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
+import { useFindCenter } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
+import { useRouter } from 'next/router';
 
-interface DetailPageProps {
-  title: string;
-}
+export default function CenterDetailPage() {
+  const router = useRouter();
+  const { cid } = router.query;
+  //cid string 거르는 로직, useRouter 에 대해 자세히 보고 추후 반드시 변경 해야함
+  const centerId = cid ? (Array.isArray(cid) ? cid[0] : cid) : '';
 
-const img =
-  'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80';
-const list = [img, img, img, img, img, img, img, img];
+  //암장 상세 정보 useQuery state
+  const {
+    isLoading: isCenterDetailLoading,
+    data: CenterDetailData,
+    isError: isCenterDetailError,
+    error: CenterDetailerror,
+  } = useFindCenter(centerId);
 
-export default function CenterDetailPage({ title }: DetailPageProps) {
-  title = '더클라이밍 마곡';
-  return (
+  return isCenterDetailLoading ? (
+    <div>로딩 중</div>
+  ) : isCenterDetailError ? (
+    <div>{CenterDetailerror}</div>
+  ) : CenterDetailData ? (
     <section className="mb-footer overflow-auto scrollbar-hide">
       <AppBar
         leftNode={<AppLogo />}
@@ -28,10 +38,14 @@ export default function CenterDetailPage({ title }: DetailPageProps) {
         }
       />
       <CenterInfoHead
-        title={title}
-        address="서울특별시 강서구 마곡동 796-3 마곡사이언스타워 7층"
+        name={CenterDetailData.name}
+        address={CenterDetailData.address}
+        tel={CenterDetailData.tel}
+        instagramUrl={CenterDetailData.instagramUrl}
+        webUrl={CenterDetailData.webUrl}
+        youtubeUrl={CenterDetailData.youtubeUrl}
       />
-      <CenterInfoContent imageList={list} />
+      <CenterInfoContent data={CenterDetailData} />
     </section>
-  );
+  ) : null;
 }

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterCharge.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterCharge.tsx
@@ -1,0 +1,46 @@
+import { CenterDetailCharge } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
+import React from 'react';
+
+interface CenterChargeProps {
+  chargeList: CenterDetailCharge[];
+}
+
+const CenterCharge = ({ chargeList }: CenterChargeProps) => {
+  //TODO - 이미지로 보기 클릭 시?
+  const handleShowImageButtonClick = () => {
+    console.dir(chargeList.map((value) => value.image));
+  };
+  return (
+    <div className="flex flex-col gap-2">
+      <div className={'flex justify-between'}>
+        <h2 className={'font-semibold text-sm'}>이용 요금</h2>
+        <button
+          className={'bg-none text-sm text-purple-500'}
+          onClick={handleShowImageButtonClick}
+        >
+          이미지로 보기
+        </button>
+      </div>
+      <ul>
+        {chargeList.map((outer, outerIdx) => (
+          <div
+            className={'flex flex-col gap-2'}
+            key={`chargeListOuter_${outerIdx}`}
+          >
+            {outer.chargeList.map((inner, innerIdx) => (
+              <li
+                className={'flex justify-between items-center'}
+                key={`chargeListInner_${innerIdx}`}
+              >
+                <text className={'w-[60%]'}>{inner.name}</text>
+                <text>{`${inner.fee}`}</text>
+              </li>
+            ))}
+          </div>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CenterCharge;

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterDetailInfo.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterDetailInfo.tsx
@@ -1,16 +1,32 @@
+import { CenterDetailResponse } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
+import CenterCharge from './CenterCharge';
+import CenterFacilities from './CenterFacilities';
+import CenterHoldList from './CenterHoldList';
+import CenterOperatingTime from './CenterOperatingTime';
+import CenterSectorList from './CenterSectorList';
 
+interface CenterDetailInfoProps {
+  data: CenterDetailResponse;
+}
 
-export const CenterDetailInfo = ({ }) => {
-    const CenterInfoTitleList = ['운영시간', '편의시설', '이용 요금', '홀드 정보', '섹터 정보'];
+export const CenterDetailInfo = ({ data }: CenterDetailInfoProps) => {
+  const {
+    operatingTimeList,
+    facilities,
+    //chargeList 의 경우 안에 chargeList 와 image 가 있음
+    chargeList,
+    holdInfoList,
+    holdInfoImg,
+    sectorInfoList,
+  } = data;
 
-    return (
-        <div className='flex flex-col px-7'>
-            {CenterInfoTitleList.map(title => (
-                <div key={title} className='flex flex-col gap-2'>
-                    <h2 className='font-semibold text-sm'>{title}</h2>
-                    <div className=' '></div>
-                </div>
-            ))}
-        </div>
-    );
+  return (
+    <div className="flex flex-col p-7 gap-8">
+      <CenterOperatingTime operatingTimeList={operatingTimeList} />
+      <CenterFacilities facilities={facilities} />
+      <CenterCharge chargeList={chargeList} />
+      <CenterHoldList holdInfoList={holdInfoList} holdInfoImg={holdInfoImg} />
+      <CenterSectorList sectorInfoList={sectorInfoList} />
+    </div>
+  );
 };

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterFacilities.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterFacilities.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface CenterFacilitiesProps {
+  facilities: string;
+}
+
+const CenterFacilities = ({ facilities }: CenterFacilitiesProps) => (
+  <div className="flex flex-col gap-2">
+    <h2 className="font-semibold text-sm">편의시설</h2>
+    <div className=" ">{facilities}</div>
+  </div>
+);
+
+export default CenterFacilities;

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterHoldList.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterHoldList.tsx
@@ -1,0 +1,45 @@
+import { HoldInfoResponse } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
+import Image from 'next/image';
+import React from 'react';
+
+interface CenterHoldListProps {
+  holdInfoList: HoldInfoResponse[];
+  holdInfoImg: string;
+}
+
+const CenterHoldList = ({ holdInfoList, holdInfoImg }: CenterHoldListProps) => {
+  //TODO : 이미지로 보기 클릭 시?
+  const handleShowImageButtonClick = () => {
+    console.dir(holdInfoImg);
+  };
+  return (
+    <div className="flex flex-col gap-2">
+      <div className={'flex justify-between'}>
+        <h2 className={'font-semibold text-sm'}>홀드 정보</h2>
+        <button
+          className={'bg-none text-sm text-purple-500'}
+          onClick={handleShowImageButtonClick}
+        >
+          이미지로 보기
+        </button>
+      </div>
+      <div className={'h-20 flex'}>
+        {holdInfoList.map((value, index) => (
+          <div
+            key={`centerHoldListImage_${index}`}
+            className="h-8 w-8 mx-1 relative"
+          >
+            <Image
+              layout="fill"
+              objectFit="scale-down"
+              src={value.image}
+              alt={value.name}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CenterHoldList;

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterOperatingTime.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterOperatingTime.tsx
@@ -1,0 +1,25 @@
+import { OperatingTime } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
+import React from 'react';
+
+interface CenterOperatingTimeProps {
+  operatingTimeList: OperatingTime[];
+}
+
+const CenterOperatingTime = ({
+  operatingTimeList,
+}: CenterOperatingTimeProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="font-semibold text-sm">운영시간</h2>
+      <ul>
+        {operatingTimeList.map((value, index) => (
+          <li
+            key={`OperatingTimes_${index}`}
+          >{`${value.day} ${value.start} - ${value.end}`}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CenterOperatingTime;

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterPost.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterPost.tsx
@@ -1,12 +1,44 @@
-import { ImageGridList } from '../../common/ImageList/ImageGridList';
+import { useGetCenterPosts } from 'climbingweb/src/hooks/queries/center-controller/useGetCenterPosts';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
 
+interface CenterPostsProps {
+  centerId: string;
+}
 
-export const CenterPost = ({ }) => {
-    const img = 'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80';
-    const list = [img, img, img, img, img, img, img, img, img, img, img, img, img, img];
-    return (
-        <div>
-            <ImageGridList imageList={list} />
-        </div>
-    );
+export const CenterPost = ({ centerId }: CenterPostsProps) => {
+  const { isLoading, data, isError, error } = useGetCenterPosts(centerId);
+  const router = useRouter();
+
+  const handleThumbnailClick = (id: string) => {
+    router.push(`/feed/${id}`);
+  };
+
+  return isLoading ? (
+    <div>로딩 중...</div>
+  ) : isError ? (
+    <div>{error}</div>
+  ) : data ? (
+    data.totalCount !== 0 ? (
+      <div className="w-full grid grid-cols-3">
+        {data.results.map((value, idx) => (
+          <div
+            key={`CenterPosts_${idx}`}
+            className="h-32 relative"
+            onClick={() => handleThumbnailClick(value.postId)}
+          >
+            <Image
+              layout="fill"
+              objectFit="cover"
+              priority
+              src={value.thumbnailUrl}
+              alt={value.postId}
+            />
+          </div>
+        ))}
+      </div>
+    ) : (
+      <div> 게시글이 없습니다. </div>
+    )
+  ) : null;
 };

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterReview.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterReview.tsx
@@ -1,57 +1,61 @@
-import { ReviewCommment } from '../../Comments/ReviewComment';
+import { useFindReviewByCenter } from 'climbingweb/src/hooks/queries/center-controller/useFindReviewByCenter';
+import { ReviewComment } from '../../Comments/ReviewComment';
 import { StarRating } from '../../common/StarRating';
 
 interface ReviewProps {
-  rank?: number;
+  id: string;
 }
 
-export const CenterReview = ({ rank }: ReviewProps) => {
+export const CenterReview = ({ id }: ReviewProps) => {
+  const { isLoading, data, isError, error } = useFindReviewByCenter(id);
   const count = 5;
-  rank = 4.3;
-  const test = {
-    content:
-      'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Consequatur accusamus esse delectus laboriosam, corporis obcaecati sit, quis ab magni, voluptate culpa. Officiis ea quibusdam animi? Ab excepturi similique obcaecati explicabo!',
-    isDeleted: false,
-    writerNickName: '이민수als95',
-    writerProfileImage:
-      'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-    createAt: '22.01.23.12:34',
-  };
-  const list = [test, test, test, test];
 
-  return (
+  return isLoading ? (
+    <div>로딩 중</div>
+  ) : isError ? (
+    <div>{error}</div>
+  ) : data ? (
     <div className="w-full px-5">
-      <div className="flex flex-row justify-between items-center py-5">
-        <div className="flex items-center gap-2">
-          <span className="text-black text-sm">
-            <span className="text-purple-500">{rank}</span>/ {count}
-          </span>
-          <StarRating count={count} initialValue={3} size="sm" />
-        </div>
-        <button className="w-16 h-6 bg-purple-500 rounded-lg text-white text-xs">
-          리뷰 작성
-        </button>
-      </div>
-      <div>
-        {list.map(
-          ({
-            content,
-            isDeleted,
-            writerNickName,
-            writerProfileImage,
-            createAt,
-          }) => (
-            <ReviewCommment
-              key={writerNickName}
-              content={content}
-              isDeleted={isDeleted}
-              writerNickName={writerNickName}
-              writerProfileImage={writerProfileImage}
-              createAt={createAt}
-            />
-          )
-        )}
-      </div>
+      {data.reviewFindResponseDtoPagination.totalCount === 0 ? (
+        <div>리뷰가 없습니다.</div>
+      ) : (
+        <>
+          <div className="flex flex-row justify-between items-center py-5">
+            <div className="flex items-center gap-2">
+              <span className="text-black text-sm">
+                <span className="text-purple-500">{data.rank}</span>/ {count}
+              </span>
+              <StarRating count={count} initialValue={3} size="sm" />
+            </div>
+            <button className="w-16 h-6 bg-purple-500 rounded-lg text-white text-xs">
+              리뷰 작성
+            </button>
+          </div>
+          <div>
+            {data.reviewFindResponseDtoPagination.results.map(
+              ({
+                content,
+                createdAt,
+                rank,
+                reviewId,
+                reviewerNickname,
+                reviewerProfileImage,
+                updatedAt,
+              }) => (
+                <ReviewComment
+                  key={reviewId}
+                  content={content}
+                  createdAt={createdAt}
+                  rank={rank}
+                  reviewerNickname={reviewerNickname}
+                  reviewerProfileImage={reviewerProfileImage}
+                  updatedAt={updatedAt}
+                />
+              )
+            )}
+          </div>
+        </>
+      )}
     </div>
-  );
+  ) : null;
 };

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterSectorList.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterSectorList.tsx
@@ -1,0 +1,27 @@
+import { SectorInfoResponse } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
+import React from 'react';
+
+interface CenterSectorListProps {
+  sectorInfoList: SectorInfoResponse[];
+}
+
+const CenterSectorList = ({ sectorInfoList }: CenterSectorListProps) => (
+  <div className="flex flex-col gap-2">
+    <h2 className="font-semibold text-sm">섹터 정보</h2>
+    <ul>
+      {sectorInfoList.map((value) => (
+        <li
+          className={'flex gap-2 justify-between items-center'}
+          key={`sectorInfoList_${value.id}`}
+        >
+          <text>{value.name}</text>
+          <text>{`${value.start} ${value.start && value.end ? '~' : ''} ${
+            value.end
+          }`}</text>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default CenterSectorList;

--- a/packages/climbingweb/src/components/CenterInfo/CenterInfoContent.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterInfoContent.tsx
@@ -4,34 +4,34 @@ import { CenterDetailInfo } from './CenterDetailInfo/CenterDetailInfo';
 import { CenterReview } from './CenterDetailInfo/CenterReview';
 import { CenterPost } from './CenterDetailInfo/CenterPost';
 import { Tab } from '../common/TabBar/type';
+import { CenterDetailResponse } from 'climbingweb/src/hooks/queries/center-controller/useFindCenter';
 
 interface ContentProps {
-  imageList: string[];
+  data: CenterDetailResponse;
 }
 
-export const CenterInfoContent = ({ imageList }: ContentProps) => {
-
+export const CenterInfoContent = ({ data }: ContentProps) => {
   const tabList: Tab[] = [
     {
       id: 1,
       tabName: '상세정보',
-      tabContent: <CenterDetailInfo />,
+      tabContent: <CenterDetailInfo data={data} />,
     },
     {
       id: 2,
       tabName: '리뷰',
-      tabContent: <CenterReview />,
+      tabContent: <CenterReview id={data.id} />,
     },
     {
       id: 3,
       tabName: '게시글',
-      tabContent: <CenterPost />,
+      tabContent: <CenterPost centerId={data.id} />,
     },
   ];
 
   return (
     <div>
-      <ImageList imageList={imageList} />
+      <ImageList imageList={data.imgList.map((value) => value.url)} />
       <TabBar tabList={tabList} />
     </div>
   );

--- a/packages/climbingweb/src/components/CenterInfo/CenterInfoHead.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterInfoHead.tsx
@@ -5,30 +5,62 @@ import YoutubeIcon from 'climbingweb/src/assets/icon/center_channel/ic_24_youtub
 import PinIcon from 'climbingweb/src/assets/icon/ic_18_pin_gray600.svg';
 
 interface HeadProps {
-  title: string;
+  name: string;
   address: string;
+  tel: string;
+  instagramUrl: string;
+  webUrl: string;
+  youtubeUrl: string;
 }
 
-export const CenterInfoHead = ({ title, address }: HeadProps) => {
+export const CenterInfoHead = ({
+  name,
+  address,
+  tel,
+  instagramUrl,
+  webUrl,
+  youtubeUrl,
+}: HeadProps) => {
+  //pinIcon click 핸들러
+  const handlePinIconClick = () => {
+    console.dir(address);
+  };
+  //telIcon click 핸들러
+  const handleTelIconClick = () => {
+    console.dir(tel);
+  };
+  //webIcon click 핸들러
+  const handleWebIconClick = () => {
+    console.dir(webUrl);
+  };
+  //instaIcon click 핸들러
+  const handleInstaIconClick = () => {
+    console.dir(instagramUrl);
+  };
+  //youtubeIcon click핸들러
+  const handleYoutubeIconClick = () => {
+    console.dir(youtubeUrl);
+  };
+
   return (
     <div className="p-4">
-      <h2 className="text-lg font-extrabold leading-6 mb-3">{title}</h2>
+      <h2 className="text-lg font-extrabold leading-6 mb-3">{name}</h2>
       <p className="text-sm flex items-center">
-        <PinIcon />
+        <PinIcon onClick={handlePinIconClick} />
         {address}
       </p>
       <div className="w-full flex flex-row px-1 pt-5">
         <div className="w-3/12 rounded-l-lg border flex items-center justify-center p-1.5">
-          <TelIcon />
+          <TelIcon onClick={handleTelIconClick} />
         </div>
         <div className="w-3/12 border flex items-center justify-center p-1.5">
-          <WebIcon />
+          <WebIcon onClick={handleWebIconClick} />
         </div>
         <div className="w-3/12 border flex items-center justify-center p-1.5">
-          <InstaIcon />
+          <InstaIcon onClick={handleInstaIconClick} />
         </div>
         <div className="w-3/12 rounded-r-lg border flex items-center justify-center p-1.5">
-          <YoutubeIcon />
+          <YoutubeIcon onClick={handleYoutubeIconClick} />
         </div>
       </div>
     </div>

--- a/packages/climbingweb/src/components/Comments/ReviewComment.tsx
+++ b/packages/climbingweb/src/components/Comments/ReviewComment.tsx
@@ -2,25 +2,34 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { StarRating } from '../common/StarRating';
 
-interface Props {
-  commentId?: string;
+// interface ReviewCommmentProps {
+//   commentId?: string;
+//   content: string;
+//   isDeleted: boolean;
+//   postId?: string;
+//   writerNickName: string;
+//   writerProfileImage: string;
+//   createAt?: string;
+//   updateAt?: string;
+// }
+
+interface ReviewCommentProps {
   content: string;
-  isDeleted: boolean;
-  postId?: string;
-  writerNickName: string;
-  writerProfileImage: string;
-  createAt?: string;
-  updateAt?: string;
+  createdAt: string;
+  rank: number;
+  reviewerNickname: string;
+  reviewerProfileImage: string;
+  updatedAt: string;
 }
 
-export const ReviewCommment = ({
+export const ReviewComment = ({
   content,
-  isDeleted,
-  writerNickName,
-  writerProfileImage,
-  createAt,
-  updateAt,
-}: Props) => {
+  createdAt,
+  rank,
+  reviewerNickname,
+  reviewerProfileImage,
+  updatedAt,
+}: ReviewCommentProps) => {
   const [readMore, setReadMore] = useState(false);
 
   return (
@@ -31,23 +40,28 @@ export const ReviewCommment = ({
             className="rounded-full"
             layout="fill"
             objectFit="cover"
-            src={writerProfileImage}
+            src={reviewerProfileImage}
             alt="comment"
           />
         </div>
         <div className=" gap-2">
           <div className="h-10 flex flex-row justify-between items-center">
             <div>
-              <p className="text-sm font-bold">{writerNickName}</p>
+              <p className="text-sm font-bold">{reviewerNickname}</p>
               <p className="text-gray-400 text-sm">
-                {updateAt ? updateAt : createAt}{' '}
+                {updatedAt ? updatedAt : createdAt}{' '}
               </p>
             </div>
-            <StarRating readOnly={true} size="sm" count={5} initialValue={4} />
+            <StarRating
+              readOnly={true}
+              size="sm"
+              count={rank}
+              initialValue={4}
+            />
           </div>
           <div className="">
             <p className={`text-sm ${readMore ? '' : 'line-clamp-3'}`}>
-              {isDeleted ? '삭제된 게시글 입니다' : content}
+              {content}
             </p>
             <span
               className="text-gray-400 inline float-right text-sm"

--- a/packages/climbingweb/src/components/common/TabBar/index.tsx
+++ b/packages/climbingweb/src/components/common/TabBar/index.tsx
@@ -2,16 +2,18 @@ import { useState } from 'react';
 import { TabBarProps } from './type';
 
 export const TabBar = ({ tabList }: TabBarProps) => {
-  const [openTab, setOpenTab] = useState(0);
+  const [openTab, setOpenTab] = useState(1);
   return (
     <>
       <div className="flex flex-wrap">
         <div className="w-full">
           <ul className="flex list-none flex-wrap pt-3 flex-row" role="tablist">
-            {tabList.map(({ id, tabName }) => (
+            {tabList.map(({ id, tabName }, index) => (
               <li key={id} className=" flex-auto text-center">
                 <p
-                  className="text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal active:bg-gray-500"
+                  className={`text-xs font-bold uppercase px-5 py-3 border-gray-300 border-[1px] block leading-normal ${
+                    openTab === index + 1 ? 'border-b-0' : ''
+                  } active:bg-gray-500`}
                   onClick={(e) => {
                     e.preventDefault();
                     setOpenTab(id);
@@ -24,7 +26,7 @@ export const TabBar = ({ tabList }: TabBarProps) => {
               </li>
             ))}
           </ul>
-          <div className="relative flex flex-col min-w-0 break-words bg-white w-full mb-6 shadow-lg rounded">
+          <div className="relative flex flex-col min-w-0 break-words bg-white w-full mb-6">
             <div className="flex-auto">
               <div className="tab-content tab-space">
                 {tabList?.map(({ id, tabContent }) => (

--- a/packages/climbingweb/src/hooks/queries/center-controller/useFindCenter.ts
+++ b/packages/climbingweb/src/hooks/queries/center-controller/useFindCenter.ts
@@ -1,0 +1,80 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import axios from 'axios';
+
+interface CenterDetailChargeElement {
+  fee: string;
+  name: string;
+}
+
+interface CenterDetailCharge {
+  chargeList: CenterDetailChargeElement[];
+  image: string;
+}
+
+interface HoldInfoResponse {
+  crayonImage: string;
+  id: string;
+  image: string;
+  name: string;
+}
+
+interface CenterImg {
+  url: string;
+}
+
+interface OperatingTime {
+  day: string;
+  end: string;
+  start: string;
+}
+
+interface SectorInfoResponse {
+  end: string;
+  id: string;
+  name: string;
+  start: string;
+}
+
+interface CenterDetailResponse {
+  address: string;
+  chargeList: CenterDetailCharge[];
+  facilities: string;
+  holdInfoImg: string;
+  holdInfoList: HoldInfoResponse[];
+  id: string;
+  imgList: CenterImg[];
+  instagramUrl: string;
+  isBookmarked: boolean;
+  name: string;
+  operatingTimeList: OperatingTime[];
+  postCount: number;
+  reviewCount: number;
+  sectorInfoList: SectorInfoResponse[];
+  tel: string;
+  webUrl: string;
+  youtubeUrl: string;
+}
+
+const findCenter = async (centerId: string) => {
+  const { data } = await axios.get<CenterDetailResponse>(`centers/${centerId}`);
+  return data;
+};
+
+export const useFindCenter = (
+  centerId: string,
+  options?: Omit<
+    UseQueryOptions<
+      CenterDetailResponse,
+      unknown,
+      CenterDetailResponse,
+      string[]
+    >,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery(['findCenter', centerId], () => findCenter(centerId), {
+    retry: 0,
+    enabled: !!centerId,
+    ...options,
+  });
+};

--- a/packages/climbingweb/src/hooks/queries/center-controller/useFindCenter.ts
+++ b/packages/climbingweb/src/hooks/queries/center-controller/useFindCenter.ts
@@ -1,41 +1,41 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import axios from 'axios';
 
-interface CenterDetailChargeElement {
+export interface CenterDetailChargeElement {
   fee: string;
   name: string;
 }
 
-interface CenterDetailCharge {
+export interface CenterDetailCharge {
   chargeList: CenterDetailChargeElement[];
   image: string;
 }
 
-interface HoldInfoResponse {
+export interface HoldInfoResponse {
   crayonImage: string;
   id: string;
   image: string;
   name: string;
 }
 
-interface CenterImg {
+export interface CenterImg {
   url: string;
 }
 
-interface OperatingTime {
+export interface OperatingTime {
   day: string;
   end: string;
   start: string;
 }
 
-interface SectorInfoResponse {
+export interface SectorInfoResponse {
   end: string;
   id: string;
   name: string;
   start: string;
 }
 
-interface CenterDetailResponse {
+export interface CenterDetailResponse {
   address: string;
   chargeList: CenterDetailCharge[];
   facilities: string;
@@ -55,11 +55,24 @@ interface CenterDetailResponse {
   youtubeUrl: string;
 }
 
+/**
+ * GET /centers/{centerId} api 의 query 함수
+ *
+ * @param centerId 검색할 암장의 centerId
+ * @returns axiosReponse.data
+ */
 const findCenter = async (centerId: string) => {
   const { data } = await axios.get<CenterDetailResponse>(`centers/${centerId}`);
   return data;
 };
 
+/**
+ * findCenter api 의 useQuery hooks
+ *
+ * @param centerId 검색할 암장의 cenerId
+ * @param options findCenter api 의 useQuery 추가 옵션
+ * @returns findCenter api 의 useQuery return 값
+ */
 export const useFindCenter = (
   centerId: string,
   options?: Omit<

--- a/packages/climbingweb/src/hooks/queries/center-controller/useFindReviewByCenter.ts
+++ b/packages/climbingweb/src/hooks/queries/center-controller/useFindReviewByCenter.ts
@@ -1,0 +1,62 @@
+import { QueryKey, useQuery, UseQueryOptions } from 'react-query';
+import axios from 'axios';
+
+interface CenterReview {
+  content: string;
+  createdAt: string;
+  rank: number;
+  reviewId: string;
+  reviewerNickname: string;
+  reviewerProfileImage: string;
+  updatedAt: string;
+}
+
+interface CenterReviewResponse {
+  centerId: string;
+  rank: number;
+  reviewFindResponseDtoPagination: {
+    nextPageNum: number;
+    previousPageNum: number;
+    results: CenterReview[];
+    totalCount: 0;
+  };
+}
+
+/**
+ * GET /centers/{centerId}/review api 의 query 함수
+ *
+ * @param centerId 리뷰를 검색할 center의 id 값
+ * @returns axiosResponse.data
+ */
+const findReviewByCenter = async (centerId: string) => {
+  const { data } = await axios.get<CenterReviewResponse>(
+    `/centers/${centerId}/review`
+  );
+  return data;
+};
+
+/**
+ * findReviewByCenter api 의 useQuery hooks 함수
+ *
+ * @param centerId 리뷰를 검색할 center의 id 값
+ * @param options useQuery 추가 옵션
+ * @returns findReviewByCenter api 의 useQuery return 값
+ */
+export const useFindReviewByCenter = (
+  centerId: string,
+  options?: Omit<
+    UseQueryOptions<
+      CenterReviewResponse,
+      unknown,
+      CenterReviewResponse,
+      QueryKey
+    >,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery<CenterReviewResponse>(
+    ['findReviewByCenter', centerId],
+    () => findReviewByCenter(centerId),
+    { retry: 0, enabled: !!centerId, ...options }
+  );
+};

--- a/packages/climbingweb/src/hooks/queries/center-controller/useGetCenterPosts.ts
+++ b/packages/climbingweb/src/hooks/queries/center-controller/useGetCenterPosts.ts
@@ -1,0 +1,53 @@
+import { useQuery, UseQueryOptions, QueryKey } from 'react-query';
+import axios from 'axios';
+
+export interface CenterPostThumbnail {
+  postId: string;
+  thumbnailUrl: string;
+}
+
+export interface CenterPostThumbnailResponse {
+  nextPageNum: number;
+  previousPageNum: number;
+  results: CenterPostThumbnail[];
+  totalCount: number;
+}
+
+/**
+ * GET /centers/{centerId}/posts api 의 query 함수
+ *
+ * @param centerId 검색할 암장의 id
+ * @returns axiosReponse.data
+ */
+const getCenterPosts = async (centerId: string) => {
+  const { data } = await axios.get<CenterPostThumbnailResponse>(
+    `/centers/${centerId}/posts`
+  );
+  return data;
+};
+
+/**
+ * getCenterPosts api의 useQuery 함수
+ *
+ * @param centerId 검색할 암장의 id
+ * @param options getCenterPosts api의 useQuery 추가 옵션
+ * @returns getCenterPosts api의 useQuery return 값
+ */
+export const useGetCenterPosts = (
+  centerId: string,
+  options?: Omit<
+    UseQueryOptions<
+      CenterPostThumbnailResponse,
+      unknown,
+      CenterPostThumbnailResponse,
+      QueryKey
+    >,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery<CenterPostThumbnailResponse>(
+    ['getCenterPosts', centerId],
+    () => getCenterPosts(centerId),
+    { retry: 0, enabled: !!centerId, ...options }
+  );
+};


### PR DESCRIPTION
## Description
feat: 암장 상세 정보 전체 백엔드 로직 추가

🥇 TODO
1. CenterInfoHead 컴포넌트 Icon 클릭 핸들러 로직 추가 : 기획 필요
2. 이미지로 보기 클릭 핸들러 로직 추가 : 기획 필요

## Changes detail

- CenterDetailPage (암장 상세 전체 페이지 컴포넌트) 리팩터링
1. url 에서 cid 받아와 백엔드 api call 하도록 변경
- 암장 상세정보 탭 관련 컴포넌트 추가
1. CenterCharge : 요금 정보 출력 컴포넌트 (이미지로 보기 포함)
2. CenterFacilities : 이용시설 출력 컴포넌트
3. CenterHoldList : 홀드 정보 출력 컴포넌트
4.  CenterOperatingTime : 이용 시간 출력 컴포넌트 (이미지로 보기 포함)
5. CenterSectorList : 섹터 정보 출력 컴포넌트
- CenterPost (암장 게시글 컴포넌트) 리팩터링
1. 섬네일 클릭 시 라우팅 해주는 로직 추가
- CenterReview (암장 리뷰 컴포넌트) 리팩터링
1. 백엔드 로직 추가
- CenterInfoContent (암장 상세 페이지 탭 컴포넌트) 리팩터링
1. 데이터 전체를 받아와 하위 컴포넌트에 데이터를 나누어 props 로 전달 하도록 변경
- CenterInfoHead (암장 상세 페이지 헤더 컴포넌트) 리팩터링
1. 클릭 핸들러 추가
- ReviewComment (암장 리뷰 개별 컴포넌트) 리팩터링
1. props 이름 백엔드에 맞게 변경
2. 삭제된 게시글 입니다. 가 백엔드에 반영되어 있지 않아, 프론트에서 해당 로직 변경
- TabBar (탭 공통 컴포넌트) 리팩터링
1. css 변경
- useFindCenter useQuery hooks 추가 : GET /centers/{centerId} api
- useFindReviewByCenter useQuery hooks 추가 : GET /centers/{centerId}/review api
- useGetCenterPosts useQuery hooks 추가 : GET /centers/{centerId}/posts api

### Checklist

- [ ] Test case
- [ ] End of work
