### PR TITLE
feat: 공통 요소 일부 추가

### DIFF
--- a/packages/climbingweb/src/components/common/Alert/Alert.tsx
+++ b/packages/climbingweb/src/components/common/Alert/Alert.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+interface AlertProps {
+  message: string;
+  setAlertOpenState: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const Alert = ({ message, setAlertOpenState }: AlertProps) => {
+  const commonCss =
+    'absolute m-2 bottom-10 z-10 flex justify-center w-full py-2 px-16 rounded bg-gray-800 text-white -translate-y-10 transition-all';
+  const [css, setCss] = useState<string>(
+    `${commonCss} opacity-0 translate-y-10`
+  );
+  // Alert 컴포넌트가 처음 렌더링 될 때, css를 변경시키기 위해 useEffect 사용
+  useEffect(() => {
+    setCss(`${commonCss} opacity-100 translate-y-0`);
+    setTimeout(() => {
+      setCss(`${commonCss} opacity-0 translate-y-10`);
+    }, 2000);
+    setTimeout(() => {
+      setAlertOpenState(false);
+    }, 2500);
+  }, [setAlertOpenState]);
+  return <div className={css}>{message}</div>;
+};
+
+export default Alert;

--- a/packages/climbingweb/src/components/common/Alert/Alert.tsx
+++ b/packages/climbingweb/src/components/common/Alert/Alert.tsx
@@ -5,6 +5,7 @@ interface AlertProps {
   setAlertOpenState: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+// 공통 alert 컴포넌트, message를 받아서 alert 메시지를 띄워준다.
 const Alert = ({ message, setAlertOpenState }: AlertProps) => {
   const commonCss =
     'absolute m-2 bottom-10 z-10 flex justify-center w-full py-2 px-16 rounded bg-gray-800 text-white -translate-y-10 transition-all';

--- a/packages/climbingweb/src/components/common/EmptyContent/EmptyContent.tsx
+++ b/packages/climbingweb/src/components/common/EmptyContent/EmptyContent.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+interface EmptyContentProps {
+  message: string;
+}
+
+// 데이터가 없을 때 사용하는 공통 empty 컴포넌트, message를 받아서 empty 메시지를 띄워준다.
+const EmptyContent = ({ message }: EmptyContentProps) => (
+  <div className="w-full text-center leading-[10]">{message}</div>
+);
+
+export default EmptyContent;

--- a/packages/climbingweb/src/components/common/Error/ErrorContent.tsx
+++ b/packages/climbingweb/src/components/common/Error/ErrorContent.tsx
@@ -1,0 +1,10 @@
+import { ServerError } from 'climbingweb/types/common';
+import React from 'react';
+
+interface ErrorContentProps {
+  error: ServerError;
+}
+
+const ErrorContent = ({ error }: ErrorContentProps) => <div>{error}</div>;
+
+export default ErrorContent;

--- a/packages/climbingweb/src/components/common/Error/ErrorContent.tsx
+++ b/packages/climbingweb/src/components/common/Error/ErrorContent.tsx
@@ -5,6 +5,7 @@ interface ErrorContentProps {
   error: ServerError;
 }
 
+// 공통 error 컴포넌트, 추후 변경 예정
 const ErrorContent = ({ error }: ErrorContentProps) => <div>{error}</div>;
 
 export default ErrorContent;

--- a/packages/climbingweb/src/components/common/Loading/Loading.tsx
+++ b/packages/climbingweb/src/components/common/Loading/Loading.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// 공통 loading 컴포넌트
 const Loading = () => (
   <div className="flex justify-center items-center">
     <div className="animate-spin inline-block w-8 h-8 border-4 border-b-blue-400 border-r-blue-400 border-t-blue-200 border-l-blue-200 rounded-full"></div>

--- a/packages/climbingweb/src/components/common/Loading/Loading.tsx
+++ b/packages/climbingweb/src/components/common/Loading/Loading.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Loading = () => (
+  <div className="flex justify-center items-center">
+    <div className="animate-spin inline-block w-8 h-8 border-4 border-b-blue-400 border-r-blue-400 border-t-blue-200 border-l-blue-200 rounded-full"></div>
+  </div>
+);
+
+export default Loading;

--- a/packages/climbingweb/types/common/index.d.ts
+++ b/packages/climbingweb/types/common/index.d.ts
@@ -8,3 +8,10 @@ export interface Pagination<T> {
   results: T[];
   totalCount: number;
 }
+
+export interface ServerError {
+  timestamp: string;
+  status: number;
+  error: string;
+  path: string;
+}


### PR DESCRIPTION
## Description
feat: 공통 요소 일부 추가

## Changes detail

- Alert 컴포넌트 추가 (하단에 메시지를 2초간 보여줌)
사용 예시

const [openAlert, setOpenAlert] = useState<boolean>(false);

const handleAlert = () => {
  setOpenAlert(true);
};

return (
      <button onClick={handleAlert}>alert</button>
      {openAlert ? (
        <Alert message="알림" setAlertOpenState={setOpenAlert} />
      ) : null}
)

![alert](https://user-images.githubusercontent.com/37992140/202069776-bd666e9b-f231-47bb-ab6f-8edcda8ee895.gif)

- Loading 컴포넌트 추가
![Loading](https://user-images.githubusercontent.com/37992140/202070016-0c377e5b-52be-4ef0-9e12-c564efa923e9.gif)


- ErrorContent 컴포넌트 추가
클라온 서버 error response 에 맞게 사용 가능하도록 추후 디자인 나오면 변경
현재는 error response 에 맞춰 메시지만 보여주는 div 인 임시 컴포넌트

- ServerError response type 추가

- EmptyContent 컴포넌트 추가
서버의 데이터가 없을 경우 사용할 공통 Empty 컴포넌트, 추후 디자인 변경 할 수 있음
넓은 빈 공간에 메시지만 중간에 보여주는 div 인 임시 컴포넌트


### Checklist

- [ ] Test case
- [ ] End of work
