### PR TITLE
fix: 앱에서 로그인 시 토큰 받아오는 타이밍 fix

### DIFF
--- a/packages/climbingapp/src/component/webview/CustomWebView.tsx
+++ b/packages/climbingapp/src/component/webview/CustomWebView.tsx
@@ -18,7 +18,7 @@ export default function CustomWebView({ url }: WebInfo) {
         'refresh-token': refreshToken,
       };
       const message = {
-        type: 'messageFromApp',
+        type: 'token',
         payload: token,
       };
 

--- a/packages/climbingweb/pages/_app.tsx
+++ b/packages/climbingweb/pages/_app.tsx
@@ -1,30 +1,32 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
-import React, { useEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import store from '../src/store';
 import { Provider } from 'react-redux';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import NavBar from 'climbingweb/src/components/common/bottomNav/NavBar';
 import navButtons from 'climbingweb/src/components/common/bottomNav/button';
 import axios from 'axios';
-import {
-  getReactNativeMessage,
-  sendReactNativeMessage,
-} from 'climbingweb/src/utils/reactNativeMessage';
 import { isDesktop } from 'react-device-detect';
 import 'react-spring-bottom-sheet/dist/style.css';
+import { useRNMessage } from 'climbingweb/src/hooks/useRNMessage';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  axios.defaults.baseURL = '' + process.env.NEXT_PUBLIC_API;
-  if (isDesktop) {
-    axios.defaults.headers.common['access-token'] =
-      '' + process.env.NEXT_PUBLIC_ACCESS_TOKEN;
-    axios.defaults.headers.common['refresh-token'] =
-      '' + process.env.NEXT_PUBLIC_REFRESH_TOKEN;
-  }
+  const { token, sendReactNativeMessage } = useRNMessage();
+  useLayoutEffect(() => {
+    if (token) {
+      axios.defaults.headers.common['access-token'] = token.accessToken;
+      axios.defaults.headers.common['refresh-token'] = token.refreshToken;
+    }
+    if (isDesktop) {
+      axios.defaults.headers.common['access-token'] =
+        '' + process.env.NEXT_PUBLIC_ACCESS_TOKEN;
+      axios.defaults.headers.common['refresh-token'] =
+        '' + process.env.NEXT_PUBLIC_REFRESH_TOKEN;
+    }
 
-  useEffect(() => {
-    getReactNativeMessage();
+    axios.defaults.baseURL = '' + process.env.NEXT_PUBLIC_API;
     axios.interceptors.response.use(function (response) {
       if (response.headers?.hasOwnProperty('access-token')) {
         sendReactNativeMessage({
@@ -37,7 +39,10 @@ function MyApp({ Component, pageProps }: AppProps) {
       }
       return response;
     });
-  });
+
+    //eslint-disable-next-line
+  }, [token]);
+
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -50,6 +55,14 @@ function MyApp({ Component, pageProps }: AppProps) {
         },
       })
   );
+  if (!token && !isDesktop) {
+    return (
+      <section className=" h-screen flex justify-center items-center">
+        <Loading />
+      </section>
+    );
+  }
+
   return (
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>

--- a/packages/climbingweb/src/hooks/useRNMessage.ts
+++ b/packages/climbingweb/src/hooks/useRNMessage.ts
@@ -1,0 +1,52 @@
+import { isAndroid, isIOS } from 'react-device-detect';
+import { useEffect, useState } from 'react';
+
+interface Message {
+  type: string;
+  payload?: any;
+}
+
+interface Token {
+  accessToken: string | number | boolean;
+  refreshToken: string | number | boolean;
+}
+
+export const useRNMessage = () => {
+  const [message, setMessage] = useState(null);
+  const [token, setToken] = useState<Token>();
+
+  const sendReactNativeMessage = ({ type, payload }: Message) => {
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type, payload }));
+    }
+  };
+
+  useEffect(() => {
+    const listener = (event: any) => {
+      const parsedData: { type: string; payload: any } = JSON.parse(event.data);
+      if (parsedData?.type === 'messageFromApp') {
+        setMessage(parsedData.payload);
+      }
+      if (parsedData?.type === 'token') {
+        setToken({
+          accessToken: parsedData.payload['access-token'],
+          refreshToken: parsedData.payload['refresh-token'],
+        });
+        sendReactNativeMessage({ type: 'webReceiveTheToken' });
+      }
+    };
+    if (isAndroid) {
+      document.addEventListener('message', listener);
+    }
+    if (isIOS) {
+      window.addEventListener('message', listener);
+    }
+    //eslint-disable-next-line
+  }, []);
+
+  return {
+    message,
+    sendReactNativeMessage,
+    token,
+  };
+};

--- a/packages/climbingweb/src/store/slices/auth.ts
+++ b/packages/climbingweb/src/store/slices/auth.ts
@@ -3,12 +3,12 @@ interface Instagram {
   instagramOAuthId?: string;
   instagramUserName?: string;
 }
-interface Token {
-  accessToken: string;
-  refreshToken: string;
+export interface Token {
+  accessToken: string | number | boolean;
+  refreshToken: string | number | boolean;
 }
 
-export interface User extends Instagram, Token {
+export interface User extends Instagram {
   armReach: string;
   height: string;
   imagePath: string;
@@ -17,21 +17,26 @@ export interface User extends Instagram, Token {
 
 interface AuthState {
   user: User | null;
+  token: Token | null;
 }
 
 const initialState: AuthState = {
   user: null,
+  token: null,
 };
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    authorize(state, action: PayloadAction<User>) {
+    getUser(state, action: PayloadAction<User>) {
       state.user = action.payload;
+    },
+    getToken(state, action: PayloadAction<Token>) {
+      state.token = action.payload;
     },
   },
 });
 
 export default authSlice.reducer;
-export const { authorize } = authSlice.actions;
+export const { getUser, getToken } = authSlice.actions;

--- a/packages/climbingweb/src/utils/reactNativeMessage.ts
+++ b/packages/climbingweb/src/utils/reactNativeMessage.ts
@@ -1,5 +1,4 @@
 import { isMobile, isAndroid, isIOS } from 'react-device-detect';
-import axios from 'axios';
 
 interface Message {
   type: string;
@@ -19,10 +18,6 @@ export const getReactNativeMessage = () => {
   const listener = (event: any) => {
     const parsedData: { type: string; payload: any } = JSON.parse(event.data);
     if (parsedData?.type === 'messageFromApp') {
-      axios.defaults.headers.common['access-token'] =
-        parsedData.payload?.['access-token'];
-      axios.defaults.headers.common['refresh-token'] =
-        parsedData.payload?.['refresh-token'];
       sendReactNativeMessage({ type: 'webReceiveTheToken' });
     }
   };


### PR DESCRIPTION
## Image
![토큰 전달 fix](https://user-images.githubusercontent.com/33804074/202645728-a5910d3a-7839-4ca4-8cd6-7b9895853da4.gif)

## Description
- RN -> web 으로 토큰 전달 시  api 먼저 호출되어 발생하던 에러 해결
- 토큰 전달 완료 전까지 Loading 창 return

## Changes detail
### APP
- 앱 메시지   type 이름  messageFromApp 으로 사용한 걸 token 으로 이름 변경
### WEB
- _app.tsx:  
  -  useLayoutEffect를 사용해 렌더링 전에 effect 작업 수행
  -  로딩 화면 추가
-  useRNMessage:
  -  RN 메시지 주고 받는 로직 훅으로 구현, 사용
-  reactNativeMessage.ts : 
  - 기존 사용하던 통신 로직,   토큰 관련 내용 제거
  - 추후에 사용안하면 제거
 

