### PR TITLE
fix: react-spring-bottom-sheet css 글로벌 import

### DIFF
--- a/packages/climbingweb/pages/_app.tsx
+++ b/packages/climbingweb/pages/_app.tsx
@@ -12,6 +12,7 @@ import {
   sendReactNativeMessage,
 } from 'climbingweb/src/utils/reactNativeMessage';
 import { isDesktop } from 'react-device-detect';
+import 'react-spring-bottom-sheet/dist/style.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
   axios.defaults.baseURL = '' + process.env.NEXT_PUBLIC_API;

--- a/packages/climbingweb/pages/center/request/index.tsx
+++ b/packages/climbingweb/pages/center/request/index.tsx
@@ -9,7 +9,6 @@ import {
 import TextArea from 'climbingweb/src/components/common/TextArea/TextArea';
 import { useState } from 'react';
 import { BottomSheet } from 'react-spring-bottom-sheet';
-import 'react-spring-bottom-sheet/dist/style.css';
 export default function ReportPage({}) {
   const [open, setOpen] = useState(false);
   const handleOpen = () => {

--- a/packages/climbingweb/pages/center/review/index.tsx
+++ b/packages/climbingweb/pages/center/review/index.tsx
@@ -6,7 +6,6 @@ import {
 } from 'climbingweb/src/components/common/AppBar/IconButton';
 import { StarRating } from 'climbingweb/src/components/common/StarRating';
 import TextArea from 'climbingweb/src/components/common/TextArea/TextArea';
-import 'react-spring-bottom-sheet/dist/style.css';
 export default function ReportPage({}) {
   return (
     <section className="mb-footer">

--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -6,7 +6,6 @@ import {
   AppLogo,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
 import Router from 'next/router';
-import 'react-spring-bottom-sheet/dist/style.css';
 import { useGetPosts } from 'climbingweb/src/hooks/queries/post/useGetPosts';
 import { useGetLaonPost } from 'climbingweb/src/hooks/queries/laon/useGetLaonPost';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';

--- a/packages/climbingweb/pages/report/index.tsx
+++ b/packages/climbingweb/pages/report/index.tsx
@@ -9,7 +9,6 @@ import {
 import TextArea from 'climbingweb/src/components/common/TextArea/TextArea';
 import { useState } from 'react';
 import { BottomSheet } from 'react-spring-bottom-sheet';
-import 'react-spring-bottom-sheet/dist/style.css';
 import ReportData from 'climbingweb/src/interface/ReportData';
 import { useCreateReport } from 'climbingweb/src/hooks/queries/post/useCreateReport';
 import { useRouter } from 'next/router';

--- a/packages/climbingweb/src/components/SettingInfo/EditMyInfo.tsx
+++ b/packages/climbingweb/src/components/SettingInfo/EditMyInfo.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { BottomSheet } from 'react-spring-bottom-sheet';
 import { DropDown } from '../common/DropDown';
-import 'react-spring-bottom-sheet/dist/style.css';
 import { ListSheet } from '../common/BottomSheetContents/ListSheet/ListSheet';
 import { Input } from '../common/Input';
 import { StringCount } from '../common/Input/StringCount';


### PR DESCRIPTION
## Description
react-spring-bottom-sheet css 를 글로벌하게 import 하여 BottomSheet 컴포넌트를 사용하는 파일마다 일일이 css 따로 import 하지 않아도 되게 변경

## Changes detail

- 
- 

### Checklist

- [ ] Test case
- [ ] End of work
