### PR TITLE
refactor: 공통 컴포넌트 추가 적용 및 자잘한 오류 수정

### DIFF
--- a/packages/climbingweb/pages/center/[cid].tsx
+++ b/packages/climbingweb/pages/center/[cid].tsx
@@ -6,6 +6,8 @@ import {
   BookMarkButton,
   OptionButton,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
+import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
 import { useFindCenter } from 'climbingweb/src/hooks/queries/center/useFindCenter';
 import { useRouter } from 'next/router';
 
@@ -13,39 +15,39 @@ export default function CenterDetailPage() {
   const router = useRouter();
   const { cid } = router.query;
   //cid string 거르는 로직, useRouter 에 대해 자세히 보고 추후 반드시 변경 해야함
-  const centerId = cid ? (Array.isArray(cid) ? cid[0] : cid) : '';
+  const centerId = cid as string;
 
   //암장 상세 정보 useQuery state
   const {
-    isLoading: isCenterDetailLoading,
     data: CenterDetailData,
     isError: isCenterDetailError,
     error: CenterDetailerror,
   } = useFindCenter(centerId);
 
-  return isCenterDetailLoading ? (
-    <div>로딩 중</div>
-  ) : isCenterDetailError ? (
-    <div>{CenterDetailerror}</div>
-  ) : CenterDetailData ? (
-    <section className="mb-footer overflow-auto scrollbar-hide">
-      <AppBar
-        leftNode={<AppLogo />}
-        rightNode={
-          <div className="flex flex-row gap-x-3">
-            <BookMarkButton /> <OptionButton />
-          </div>
-        }
-      />
-      <CenterInfoHead
-        name={CenterDetailData.name}
-        address={CenterDetailData.address}
-        tel={CenterDetailData.tel}
-        instagramUrl={CenterDetailData.instagramUrl}
-        webUrl={CenterDetailData.webUrl}
-        youtubeUrl={CenterDetailData.youtubeUrl}
-      />
-      <CenterInfoContent data={CenterDetailData} />
-    </section>
-  ) : null;
+  if (isCenterDetailError) return <ErrorContent error={CenterDetailerror} />;
+
+  if (CenterDetailData)
+    return (
+      <section className="mb-footer overflow-auto scrollbar-hide">
+        <AppBar
+          leftNode={<AppLogo />}
+          rightNode={
+            <div className="flex flex-row gap-x-3">
+              <BookMarkButton /> <OptionButton />
+            </div>
+          }
+        />
+        <CenterInfoHead
+          name={CenterDetailData.name}
+          address={CenterDetailData.address}
+          tel={CenterDetailData.tel}
+          instagramUrl={CenterDetailData.instagramUrl}
+          webUrl={CenterDetailData.webUrl}
+          youtubeUrl={CenterDetailData.youtubeUrl}
+        />
+        <CenterInfoContent data={CenterDetailData} />
+      </section>
+    );
+
+  return <Loading />;
 }

--- a/packages/climbingweb/pages/center/index.tsx
+++ b/packages/climbingweb/pages/center/index.tsx
@@ -5,6 +5,9 @@ import {
   Empty,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
 import { useGetCenterList } from 'climbingweb/src/hooks/queries/center/useGetCenterList';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
+import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
+import EmptyContent from 'climbingweb/src/components/common/EmptyContent/EmptyContent';
 
 export default function CenterPage({}) {
   //새로운 세팅 리스트 useQuery state
@@ -29,43 +32,56 @@ export default function CenterPage({}) {
     error: newlyRegisteredError,
   } = useGetCenterList('newly_registered');
 
-  return (
-    <section className="mb-footer">
-      <AppBar leftNode={<AppLogo />} title=" " rightNode={<Empty />} />
-      <div className="pl-4 flex flex-col gap-6">
-        <div className="flex flex-col gap-4">
-          <h2 className="text-lg font-extrabold leading-6">{'새로운 세팅'}</h2>
-          {isNewSettingLoading ? (
-            <div>로딩 중</div>
-          ) : isNewSettingError ? (
-            <div>{newSettingError}</div>
-          ) : newSettingData ? (
-            <CenterResultList centerList={newSettingData.results} />
-          ) : null}
+  if (isNewSettingError) return <ErrorContent error={newSettingError} />;
+  if (isBookmarkError) return <ErrorContent error={bookmarkError} />;
+  if (isNewlyRegisteredError)
+    return <ErrorContent error={newlyRegisteredError} />;
+
+  if (isNewSettingLoading || isBookmarkLoading || isNewlyRegisteredLoading)
+    return <Loading />;
+
+  if (newSettingData && bookmarkData && newlyRegisteredData)
+    return (
+      <section className="mb-footer">
+        <AppBar leftNode={<AppLogo />} title=" " rightNode={<Empty />} />
+        <div className="pl-4 flex flex-col gap-6">
+          <div className="flex flex-col gap-4">
+            <h2 className="text-lg font-extrabold leading-6">
+              {'새로운 세팅'}
+            </h2>
+            {isNewSettingLoading ? (
+              <Loading />
+            ) : newSettingData.totalCount !== 0 ? (
+              <CenterResultList centerList={newSettingData.results} />
+            ) : (
+              <EmptyContent message="새로운 세팅을 한 암장이 없습니다." />
+            )}
+          </div>
+          <div className="flex flex-col gap-4">
+            <h2 className="text-lg font-extrabold leading-6">
+              {'즐겨찾는 암장'}
+            </h2>
+            {isBookmarkLoading ? (
+              <Loading />
+            ) : bookmarkData.totalCount !== 0 ? (
+              <CenterResultList centerList={bookmarkData.results} />
+            ) : (
+              <EmptyContent message="즐겨찾기 한 암장이 없습니다." />
+            )}
+          </div>
+          <div className="flex flex-col gap-4">
+            <h2 className="text-lg font-extrabold leading-6">
+              {'새로운 암장'}
+            </h2>
+            {isNewlyRegisteredLoading ? (
+              <Loading />
+            ) : newlyRegisteredData.totalCount !== 0 ? (
+              <CenterResultList centerList={newlyRegisteredData.results} />
+            ) : (
+              <EmptyContent message="새로운 암장이 없습니다." />
+            )}
+          </div>
         </div>
-        <div className="flex flex-col gap-4">
-          <h2 className="text-lg font-extrabold leading-6">
-            {'즐겨찾는 암장'}
-          </h2>
-          {isBookmarkLoading ? (
-            <div>로딩 중</div>
-          ) : isBookmarkError ? (
-            <div>{bookmarkError}</div>
-          ) : bookmarkData ? (
-            <CenterResultList centerList={bookmarkData.results} />
-          ) : null}
-        </div>
-        <div className="flex flex-col gap-4">
-          <h2 className="text-lg font-extrabold leading-6">{'새로운 암장'}</h2>
-          {isNewlyRegisteredLoading ? (
-            <div>로딩 중</div>
-          ) : isNewlyRegisteredError ? (
-            <div>{newlyRegisteredError}</div>
-          ) : newlyRegisteredData ? (
-            <CenterResultList centerList={newlyRegisteredData.results} />
-          ) : null}
-        </div>
-      </div>
-    </section>
-  );
+      </section>
+    );
 }

--- a/packages/climbingweb/pages/center/index.tsx
+++ b/packages/climbingweb/pages/center/index.tsx
@@ -81,4 +81,6 @@ export default function CenterPage({}) {
         </div>
       </section>
     );
+
+  return <Loading />;
 }

--- a/packages/climbingweb/pages/center/index.tsx
+++ b/packages/climbingweb/pages/center/index.tsx
@@ -37,9 +37,6 @@ export default function CenterPage({}) {
   if (isNewlyRegisteredError)
     return <ErrorContent error={newlyRegisteredError} />;
 
-  if (isNewSettingLoading || isBookmarkLoading || isNewlyRegisteredLoading)
-    return <Loading />;
-
   if (newSettingData && bookmarkData && newlyRegisteredData)
     return (
       <section className="mb-footer">

--- a/packages/climbingweb/pages/feed/[fid].tsx
+++ b/packages/climbingweb/pages/feed/[fid].tsx
@@ -4,6 +4,7 @@ import {
   ModifiedButton,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
 import { ListSheet } from 'climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
 import HomeFeed from 'climbingweb/src/components/HomeFeed/HomeFeed';
 import { useGetPost } from 'climbingweb/src/hooks/queries/post/useGetPost';
 import { useRouter } from 'next/router';
@@ -16,7 +17,7 @@ export default function FeedPage({}) {
   const router = useRouter();
   const { fid } = router.query;
   //fid string 거르는 로직, useRouter 에 대해 자세히 보고 추후 반드시 변경 해야함
-  const feedId = fid ? (Array.isArray(fid) ? fid[0] : fid) : '';
+  const feedId = fid as string;
 
   const {
     data: postData,
@@ -41,5 +42,5 @@ export default function FeedPage({}) {
       </section>
     );
 
-  return <div>로딩 중...</div>;
+  return <Loading />;
 }

--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -5,14 +5,15 @@ import {
   ModifiedButton,
   AppLogo,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
-import Router from 'next/router';
 import { useGetPosts } from 'climbingweb/src/hooks/queries/post/useGetPosts';
 import { useGetLaonPost } from 'climbingweb/src/hooks/queries/laon/useGetLaonPost';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
 import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
 import Loading from 'climbingweb/src/components/common/Loading/Loading';
+import { useRouter } from 'next/router';
 
 const Home: NextPage = () => {
+  const router = useRouter();
   //laon feed data useQuery
   const {
     data: laonPostsData,
@@ -35,7 +36,7 @@ const Home: NextPage = () => {
 
   //피드 추가 버튼 클릭 핸들러
   const onClickCreateFeed = () => {
-    Router.push('/feed/create');
+    router.push('/feed/create');
   };
 
   //intersect 핸들러

--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -9,6 +9,8 @@ import Router from 'next/router';
 import { useGetPosts } from 'climbingweb/src/hooks/queries/post/useGetPosts';
 import { useGetLaonPost } from 'climbingweb/src/hooks/queries/laon/useGetLaonPost';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
+import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
 
 const Home: NextPage = () => {
   //laon feed data useQuery
@@ -49,8 +51,8 @@ const Home: NextPage = () => {
     { threshold: 1 }
   );
 
-  if (isPostsDataError) return <div>{postsDataError}</div>;
-  if (isLaonPostsDataError) return <div>{laonPostsDataError}</div>;
+  if (isPostsDataError) return <ErrorContent error={postsDataError} />;
+  if (isLaonPostsDataError) return <ErrorContent error={laonPostsDataError} />;
 
   if (postsData && laonPostsData)
     return (
@@ -59,13 +61,11 @@ const Home: NextPage = () => {
           leftNode={<AppLogo />}
           rightNode={<ModifiedButton onClick={onClickCreateFeed} />}
         />
-        <>
-          {laonPostsData.pages.map((page) => {
-            return page.results.map((result, index) => (
-              <HomeFeed key={`laonPostsDataFeed_${index}`} postData={result} />
-            ));
-          })}
-        </>
+        {laonPostsData.pages.map((page) => {
+          return page.results.map((result, index) => (
+            <HomeFeed key={`laonPostsDataFeed_${index}`} postData={result} />
+          ));
+        })}
         {!hasNextLaonPosts ? (
           <div className="m-4 font-medium">
             <div className="h-[1px] my-2 bg-slate-300"></div>
@@ -73,22 +73,20 @@ const Home: NextPage = () => {
             <div className="h-[1px] my-2 bg-slate-300"></div>
           </div>
         ) : null}
-        <>
-          {postsData.pages.map((page) => {
-            return page.results.map((result, index) => (
-              <HomeFeed key={`postsDataFeed_${index}`} postData={result} />
-            ));
-          })}
-        </>
+        {postsData.pages.map((page) => {
+          return page.results.map((result, index) => (
+            <HomeFeed key={`postsDataFeed_${index}`} postData={result} />
+          ));
+        })}
         {!isFetchingPosts && !isFetchingLaonPosts ? (
           <div className="h-[1px] bg-slate-300" ref={target}></div>
         ) : (
-          <div>로딩 중...</div>
+          <Loading />
         )}
       </div>
     );
 
-  return <div>로딩 중...</div>;
+  return <Loading />;
 };
 
 export default Home;

--- a/packages/climbingweb/pages/search/index.tsx
+++ b/packages/climbingweb/pages/search/index.tsx
@@ -1,7 +1,6 @@
 import CenterResult from 'climbingweb/src/components/common/CenterResult/CenterResult';
 import { Input } from 'climbingweb/src/components/common/Input';
 import UserResult from 'climbingweb/src/components/SearchResult/UserResult/UserResult';
-import { useBTSheet } from 'climbingweb/src/hooks/useBtSheet';
 import React from 'react';
 import { useState } from 'react';
 import SearchIcon from 'climbingweb/src/assets/icon/ic_24_search_gray800.svg';
@@ -9,24 +8,27 @@ import { useSearchCenter } from 'climbingweb/src/hooks/queries/center/useSearchC
 import { useSearchUser } from 'climbingweb/src/hooks/queries/user/useSearchUser';
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
 import { AppLogo } from 'climbingweb/src/components/common/AppBar/IconButton';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
+import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
 
 const SearchPage = () => {
-  const { renderSheet } = useBTSheet();
   //search input value state
   const [inputValue, setInputValue] = useState<string>('');
 
   //search 유저 결과 state
   const {
-    isLoading: isUserListLoading,
-    data: userData,
-    isError: isUserListError,
+    isLoading: isUserDataListLoading,
+    data: userDataList,
+    isError: isUserDataListError,
+    error: userDataListError,
   } = useSearchUser(inputValue);
 
   //search 암장 결과 state
   const {
-    isLoading: isCenterListLoading,
-    data: centerData,
-    isError: isCenterListError,
+    isLoading: isCenterDataListLoading,
+    data: centerDataList,
+    isError: isCenterDataListError,
+    error: centerDataListError,
   } = useSearchCenter(inputValue);
 
   return (
@@ -39,15 +41,16 @@ const SearchPage = () => {
           leftNode={<SearchIcon />}
         />
       </div>
-      {isCenterListLoading ? (
-        <div>로딩 중</div>
-      ) : isCenterListError ? (
-        <div>에러</div>
-      ) : centerData !== undefined && centerData.results.length !== 0 ? (
+      {isCenterDataListLoading ? (
+        <Loading />
+      ) : isCenterDataListError ? (
+        <ErrorContent error={centerDataListError} />
+      ) : centerDataList !== undefined &&
+        centerDataList.results.length !== 0 ? (
         <div className="flex flex-col ml-5 mt-5">
           <span className="mb-3">암장</span>
           <div className="flex 'mb-footer overflow-auto scrollbar-hide'">
-            {centerData.results.map((value, index) => (
+            {centerDataList.results.map((value, index) => (
               <CenterResult
                 key={`CenterResult${index}`}
                 reviewRank={value.reviewRank}
@@ -59,21 +62,21 @@ const SearchPage = () => {
           </div>
         </div>
       ) : null}
-      {centerData !== undefined &&
-      centerData.results.length !== 0 &&
-      userData !== undefined &&
-      userData.results.length !== 0 ? (
+      {centerDataList !== undefined &&
+      centerDataList.results.length !== 0 &&
+      userDataList !== undefined &&
+      userDataList.results.length !== 0 ? (
         <div className="bg-gray-400 w-full h-[1px] mx-[20px] my-3"></div>
       ) : null}
-      {isUserListLoading ? (
-        <div>로딩 중</div>
-      ) : isUserListError ? (
-        <div>에러</div>
-      ) : userData !== undefined && userData.results.length !== 0 ? (
-        <div className="flex flex-col ml-5 mt-5">
+      {isUserDataListLoading ? (
+        <Loading />
+      ) : isUserDataListError ? (
+        <ErrorContent error={userDataListError} />
+      ) : userDataList !== undefined && userDataList.results.length !== 0 ? (
+        <div className="flex flex-col ml-2 mt-5">
           <span className="mb-3">라온</span>
-          <div className="flex 'mb-footer overflow-auto scrollbar-hide'">
-            {userData.results.map((value, index) => (
+          <div className="flex mb-footer overflow-auto scrollbar-hide">
+            {userDataList.results.map((value, index) => (
               <UserResult
                 key={`RaonResult${index}`}
                 imagePath={value.imagePath}
@@ -84,7 +87,6 @@ const SearchPage = () => {
           </div>
         </div>
       ) : null}
-      {renderSheet()}
     </div>
   );
 };

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterPost.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterPost.tsx
@@ -1,6 +1,9 @@
 import { useGetCenterPosts } from 'climbingweb/src/hooks/queries/center/useGetCenterPosts';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
+import EmptyContent from '../../common/EmptyContent/EmptyContent';
+import ErrorContent from '../../common/Error/ErrorContent';
+import Loading from '../../common/Loading/Loading';
 
 interface CenterPostsProps {
   centerId: string;
@@ -14,7 +17,7 @@ export const CenterPost = ({ centerId }: CenterPostsProps) => {
     router.push(`/feed/${id}`);
   };
 
-  if (isError) return <div>{error}</div>;
+  if (isError) return <ErrorContent error={error} />;
 
   if (!!data)
     return data.totalCount !== 0 ? (
@@ -36,8 +39,8 @@ export const CenterPost = ({ centerId }: CenterPostsProps) => {
         ))}
       </div>
     ) : (
-      <div> 게시글이 없습니다. </div>
+      <EmptyContent message="게시글이 없습니다." />
     );
 
-  return <div>로딩 중...</div>;
+  return <Loading />;
 };

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterReview.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterReview.tsx
@@ -1,5 +1,7 @@
 import { useFindReviewByCenter } from 'climbingweb/src/hooks/queries/center/useFindReviewByCenter';
 import { ReviewComment } from '../../Comments/ReviewComment';
+import ErrorContent from '../../common/Error/ErrorContent';
+import Loading from '../../common/Loading/Loading';
 import { StarRating } from '../../common/StarRating';
 
 interface ReviewProps {
@@ -7,55 +9,56 @@ interface ReviewProps {
 }
 
 export const CenterReview = ({ id }: ReviewProps) => {
-  const { isLoading, data, isError, error } = useFindReviewByCenter(id);
+  const { data, isError, error } = useFindReviewByCenter(id);
   const count = 5;
 
-  return isLoading ? (
-    <div>로딩 중</div>
-  ) : isError ? (
-    <div>{error}</div>
-  ) : data ? (
-    <div className="w-full px-5">
-      {data.reviewFindResponseDtoPagination.totalCount === 0 ? (
-        <div>리뷰가 없습니다.</div>
-      ) : (
-        <>
-          <div className="flex flex-row justify-between items-center py-5">
-            <div className="flex items-center gap-2">
-              <span className="text-black text-sm">
-                <span className="text-purple-500">{data.rank}</span>/ {count}
-              </span>
-              <StarRating count={count} initialValue={3} size="sm" />
+  if (isError) return <ErrorContent error={error} />;
+
+  if (data)
+    return data ? (
+      <div className="w-full px-5">
+        {data.reviewFindResponseDtoPagination.totalCount === 0 ? (
+          <div>리뷰가 없습니다.</div>
+        ) : (
+          <>
+            <div className="flex flex-row justify-between items-center py-5">
+              <div className="flex items-center gap-2">
+                <span className="text-black text-sm">
+                  <span className="text-purple-500">{data.rank}</span>/ {count}
+                </span>
+                <StarRating count={count} initialValue={3} size="sm" />
+              </div>
+              <button className="w-16 h-6 bg-purple-500 rounded-lg text-white text-xs">
+                리뷰 작성
+              </button>
             </div>
-            <button className="w-16 h-6 bg-purple-500 rounded-lg text-white text-xs">
-              리뷰 작성
-            </button>
-          </div>
-          <div>
-            {data.reviewFindResponseDtoPagination.results.map(
-              ({
-                content,
-                createdAt,
-                rank,
-                reviewId,
-                reviewerNickname,
-                reviewerProfileImage,
-                updatedAt,
-              }) => (
-                <ReviewComment
-                  key={reviewId}
-                  content={content}
-                  createdAt={createdAt}
-                  rank={rank}
-                  reviewerNickname={reviewerNickname}
-                  reviewerProfileImage={reviewerProfileImage}
-                  updatedAt={updatedAt}
-                />
-              )
-            )}
-          </div>
-        </>
-      )}
-    </div>
-  ) : null;
+            <div>
+              {data.reviewFindResponseDtoPagination.results.map(
+                ({
+                  content,
+                  createdAt,
+                  rank,
+                  reviewId,
+                  reviewerNickname,
+                  reviewerProfileImage,
+                  updatedAt,
+                }) => (
+                  <ReviewComment
+                    key={reviewId}
+                    content={content}
+                    createdAt={createdAt}
+                    rank={rank}
+                    reviewerNickname={reviewerNickname}
+                    reviewerProfileImage={reviewerProfileImage}
+                    updatedAt={updatedAt}
+                  />
+                )
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    ) : null;
+
+  return <Loading />;
 };

--- a/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
@@ -12,6 +12,8 @@ import { BottomSheet } from 'react-spring-bottom-sheet';
 import { ListSheet } from '../common/BottomSheetContents/ListSheet/ListSheet';
 import { PostDetailResponse } from 'climbingweb/types/response/post';
 import { UserPostDetailResponse } from 'climbingweb/types/response/laon';
+import Loading from '../common/Loading/Loading';
+import ErrorContent from '../common/Error/ErrorContent';
 
 interface HomeFeedProps {
   postData: PostDetailResponse | UserPostDetailResponse;
@@ -73,9 +75,9 @@ const HomeFeed = ({ postData }: HomeFeedProps) => {
   //옵션 도트 클릭 핸들러
   const handleOptionDotClick = () => setOpenBTSheet(true);
 
-  if (isCommentError) return <div>{commentError}</div>;
+  if (isCommentError) return <ErrorContent error={commentError} />;
 
-  if (!!postData && !!commentData)
+  if (commentData)
     return (
       <section className={'w-full mb-footer'}>
         <FeedHeader
@@ -105,7 +107,7 @@ const HomeFeed = ({ postData }: HomeFeedProps) => {
       </section>
     );
 
-  return <div>로딩 중...</div>;
+  return <Loading />;
 };
 
 export default HomeFeed;

--- a/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
@@ -7,19 +7,20 @@ import ImageSlider from '../ImageSlider/ImageSlider';
 import { useCreateLike } from 'climbingweb/src/hooks/queries/post/useCreateLike';
 import { useDeleteLike } from 'climbingweb/src/hooks/queries/post/useDeleteLike';
 import { useFindAllParentCommentAndThreeChildComment } from 'climbingweb/src/hooks/queries/post/useFindAllParentCommentAndThreeChildComment';
-import Router from 'next/router';
 import { BottomSheet } from 'react-spring-bottom-sheet';
 import { ListSheet } from '../common/BottomSheetContents/ListSheet/ListSheet';
 import { PostDetailResponse } from 'climbingweb/types/response/post';
 import { UserPostDetailResponse } from 'climbingweb/types/response/laon';
 import Loading from '../common/Loading/Loading';
 import ErrorContent from '../common/Error/ErrorContent';
+import { useRouter } from 'next/router';
 
 interface HomeFeedProps {
   postData: PostDetailResponse | UserPostDetailResponse;
 }
 
 const HomeFeed = ({ postData }: HomeFeedProps) => {
+  const router = useRouter();
   //바텀시트 open state
   const [openBTSheet, setOpenBTSheet] = useState<boolean>(false);
 
@@ -69,11 +70,15 @@ const HomeFeed = ({ postData }: HomeFeedProps) => {
 
   //댓글 더보기 클릭 핸들러
   const handleMoreCommentClick = () => {
-    Router.push(`/feed/${postData.postId}/comments`);
+    router.push(`/feed/${postData.postId}/comments`);
   };
 
   //옵션 도트 클릭 핸들러
   const handleOptionDotClick = () => setOpenBTSheet(true);
+
+  //바텀시트 리스트 클릭 핸들러
+  const handleBTSheetListClick = () =>
+    router.push(`/report/${postData.postId}`);
 
   if (isCommentError) return <ErrorContent error={commentError} />;
 
@@ -101,7 +106,7 @@ const HomeFeed = ({ postData }: HomeFeedProps) => {
           <ListSheet
             headerTitle={''}
             list={['신고하기']}
-            onSelect={() => Router.push(`/report/${postData.postId}`)}
+            onSelect={handleBTSheetListClick}
           />
         </BottomSheet>
       </section>

--- a/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
+++ b/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
@@ -1,5 +1,6 @@
 import { useCreateLaon } from 'climbingweb/src/hooks/queries/laon/useCreateLaon';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import React from 'react';
 
 interface UserProps {
@@ -13,35 +14,33 @@ interface UserProps {
  * 라온 버튼 클릭 시, 라온 추가 신청이 된다.
  */
 const UserResult = ({ imagePath, isLaon, nickname }: UserProps) => {
+  const router = useRouter();
+
   //라온 신청 mutation
-  const {
-    mutate: createLaonMutate,
-    isSuccess: createLaonIsSuccess,
-    isError: createLaonIsError,
-    error: createLaonError,
-  } = useCreateLaon(nickname);
+  const { mutate: createLaonMutate } = useCreateLaon(nickname);
 
   // 라온 신청 버튼 클릭 핸들링 함수
   const handleRaonButtonClick = () => {
     createLaonMutate();
-    if (createLaonIsSuccess) {
-      alert('라온 신청 완료');
-    } else if (createLaonIsError) {
-      alert(createLaonError);
-    }
+  };
+  // 라온 검색 결과 클릭 핸들링 함수
+  const handleUserResultClick = () => {
+    router.push(`/users/name/${nickname}`);
   };
   return (
-    <div className="relative flex flex-col items-center text-center w-[75px] h-[110px] rounded-[4px] border-gray-400 border-2 text-[8px] p-1">
-      <Image
-        className="rounded-full"
-        src={imagePath}
-        alt={'raonImage'}
-        width={'45px'}
-        height={'45px'}
-      />
-      {nickname}
+    <div className="relative flex flex-col mx-2 items-center text-center w-[75px] h-[110px] rounded-[4px] border-gray-400 border-2 text-[8px] p-1">
+      <div onClick={handleUserResultClick}>
+        <Image
+          className="rounded-full"
+          src={imagePath}
+          alt={'raonImage'}
+          width={'45px'}
+          height={'45px'}
+        />
+        {nickname}
+      </div>
       <button
-        className="absolute bg-purple-500 text-center bottom-0 my-[6px] w-[36px] h-[16px] rounded-full text-white"
+        className="absolute bg-purple-500 text-center bottom-0 my-[6px] w-[36px] h-[16px] rounded-full text-white disabled:bg-slate-400"
         onClick={handleRaonButtonClick}
         disabled={isLaon}
       >

--- a/packages/climbingweb/types/response/center/index.d.ts
+++ b/packages/climbingweb/types/response/center/index.d.ts
@@ -5,8 +5,10 @@ import { Pagination } from '../../common/index';
  * 특이사항: Pagination«CenterPreviewResponseDto»
  */
 export interface CenterPreviewResponse {
-  centerImage: string;
-  centerName: string;
+  id: string;
+  name: string;
+  reviewRank: number;
+  thumbnailUrl: string;
 }
 
 /**


### PR DESCRIPTION
## Description
refactor: 공통 컴포넌트 추가 적용 및 자잘한 오류 수정

## Changes detail

- 공통 컴포넌트 `Loading` `ErrorContent` `EmptyContent` 필요한 부분 적용
  1. /center/[cid]
  2. /center
  3. /feed/[fid]
  4. / (home)
  5. /search
- router.query 의 type 이 string | string[] | undefined 라서 string 으로 거르는 로직의 코드 변경
  1. /center/[cid]
  2. /feed/[fid]
- next.js 싱글톤 Router 사용하던 것 useRouter 로 변경
  1. / (home)
  2. <HomeFeed />
- react-query hooks 를 통해 가져온 data 의 변수명을 일관성 있게 수정
  1. /search
  2. <HoldListModal />
- CenterPreviewReponse 인터페이스 key 값 잘못 사용 되었던 것 수정

### Checklist

- [ ] Test case
- [ ] End of work
