### PR TITLE
feat: 댓글 페이지 및 대댓글 페이지 기능 추가

### DIFF
--- a/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
@@ -79,13 +79,15 @@ export default function CommentDetailPage() {
   //댓글 수정 useMutation
   const { mutate: updateCommentMutate } = useUpdateComment(
     feedId,
-    selectedComment.commentId
+    selectedComment.commentId,
+    parentCommentId
   );
 
   //댓글 삭제 useMutation
   const { mutate: deleteCommentMutate } = useDeleteComment(
     feedId,
-    selectedComment.commentId
+    selectedComment.commentId,
+    parentCommentId
   );
 
   //뒤로가기 핸들러
@@ -170,7 +172,7 @@ export default function CommentDetailPage() {
           createdAt={createdAt}
           updatedAt={updatedAt}
           isOwner={isOwner}
-          isParent={true}
+          isParent={false}
           handleModifyCommentClick={handleModifyCommentClick}
           handleDeleteCommentClick={handleDeleteCommentClick}
         />

--- a/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
@@ -1,0 +1,144 @@
+import { CommentInput } from 'climbingweb/src/components/Comments/CommentInput';
+import { Commment } from 'climbingweb/src/components/Comments/Comments';
+import { AppBar } from 'climbingweb/src/components/common/AppBar';
+import {
+  BackButton,
+  Empty,
+} from 'climbingweb/src/components/common/AppBar/IconButton';
+import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
+import {
+  useCreateChildComment,
+  useFindAllChildrenComment,
+  useFindAllParentCommentAndThreeChildComment,
+} from 'climbingweb/src/hooks/queries/post/queryKey';
+import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
+import { CommentCreateRequest } from 'climbingweb/types/request/post';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+export default function CommentDetailPage() {
+  const router = useRouter();
+  const { fid, cid } = router.query;
+  const feedId = fid as string;
+  const commentId = cid as string;
+
+  //현재 답댓글 페이지의 부모 댓글을 api 에서 지원하지 않기 때문에 따로 가져옴
+  const {
+    data: parentCommentsData,
+    isError: isParentCommentsDataError,
+    error: parentCommentsDataError,
+  } = useFindAllParentCommentAndThreeChildComment(feedId);
+
+  const parentCommentData = parentCommentsData?.pages[0].results.find(
+    (result) => result.commentId === commentId
+  );
+
+  //현재 답댓글 페이지의 답댓글들을 가져옴
+  const {
+    data: childrenCommentData,
+    isError: isChildrenCommentDataError,
+    error: childrenCommentDataError,
+    hasNextPage: hasChildrenCommentNextPage,
+    fetchNextPage: fetchChildrenCommentNextPage,
+    isFetchingNextPage: isFetchingChildrenCommentNextPage,
+  } = useFindAllChildrenComment(commentId);
+
+  //답댓글 생성 useMutation
+  const { mutate: createCommentMutate } = useCreateChildComment(
+    feedId,
+    commentId
+  );
+
+  //뒤로가기 핸들러
+  const handleBackButtonClick = () => {
+    router.back();
+  };
+
+  //등록 버튼 클릭 핸들러
+  const handleSubmitCommentClick = (request: CommentCreateRequest) => {
+    createCommentMutate(request);
+  };
+
+  //infinite scroll 핸들러
+  const target = useIntersectionObserver(
+    async (entry, observer) => {
+      observer.unobserve(entry.target);
+      if (hasChildrenCommentNextPage) {
+        fetchChildrenCommentNextPage();
+      }
+    },
+    { threshold: 1 }
+  );
+
+  if (isParentCommentsDataError || isChildrenCommentDataError) {
+    return (
+      <ErrorContent
+        error={parentCommentsDataError || childrenCommentDataError}
+      />
+    );
+  }
+
+  if (parentCommentData && childrenCommentData) {
+    const {
+      content,
+      isDeleted,
+      writerNickname,
+      writerProfileImage,
+      createdAt,
+      updatedAt,
+    } = parentCommentData;
+
+    return (
+      <div className="mb-footer overflow-auto scrollbar-hide">
+        <AppBar
+          leftNode={<BackButton onClick={handleBackButtonClick} />}
+          title={`답댓글 ${childrenCommentData.pages[0].totalCount}`}
+          rightNode={<Empty />}
+        />
+        <Commment
+          postId={feedId}
+          commentId={commentId}
+          content={content}
+          isDeleted={isDeleted}
+          writerNickname={writerNickname}
+          writerProfileImage={writerProfileImage}
+          createdAt={createdAt}
+          updatedAt={updatedAt}
+          isParent={true}
+        />
+        <div className="pl-10">
+          {childrenCommentData.pages.map((page) => {
+            return page.results.map((comment) => {
+              return (
+                <Commment
+                  key={comment.commentId}
+                  postId={comment.postId}
+                  commentId={comment.commentId}
+                  content={comment.content}
+                  isDeleted={comment.isDeleted}
+                  writerNickname={comment.writerNickname}
+                  writerProfileImage={comment.writerProfileImage}
+                  createdAt={comment.createdAt}
+                  updatedAt={comment.updatedAt}
+                  isParent={false}
+                />
+              );
+            });
+          })}
+          {!isFetchingChildrenCommentNextPage ? (
+            <div className="h-[1px]" ref={target}></div>
+          ) : (
+            <Loading />
+          )}
+        </div>
+        <CommentInput
+          commentId={commentId}
+          onClickSubmit={handleSubmitCommentClick}
+        />
+      </div>
+    );
+  }
+
+  return <Loading />;
+}

--- a/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
@@ -1,40 +1,66 @@
 import { CommentInput } from 'climbingweb/src/components/Comments/CommentInput';
-import { Commment } from 'climbingweb/src/components/Comments/Comments';
+import { Comment } from 'climbingweb/src/components/Comments/Comments';
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
 import {
   BackButton,
   Empty,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
+import { ButtonSheet } from 'climbingweb/src/components/common/BottomSheetContents/ButtonSheet';
 import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
 import Loading from 'climbingweb/src/components/common/Loading/Loading';
 import {
   useCreateChildComment,
+  useDeleteComment,
   useFindAllChildrenComment,
-  useFindAllParentCommentAndThreeChildComment,
+  useFindAllParentComment,
+  useUpdateComment,
 } from 'climbingweb/src/hooks/queries/post/queryKey';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
-import { CommentCreateRequest } from 'climbingweb/types/request/post';
+import {
+  CommentCreateRequest,
+  CommentUpdateRequest,
+} from 'climbingweb/types/request/post';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useRef, useState } from 'react';
+import { BottomSheet } from 'react-spring-bottom-sheet';
+
+interface CommentInputState {
+  content: string;
+  isEdit: boolean;
+  commentId: string;
+}
 
 export default function CommentDetailPage() {
   const router = useRouter();
   const { fid, cid } = router.query;
   const feedId = fid as string;
-  const commentId = cid as string;
+  const parentCommentId = cid as string;
 
-  //현재 답댓글 페이지의 부모 댓글을 api 에서 지원하지 않기 때문에 따로 가져옴
+  //바텀시트 open state
+  const [openBTSheet, setOpenBTSheet] = useState<boolean>(false);
+
+  //수정 선택한 댓글 client state
+  const [selectedComment, setSelectedComment] = useState<CommentInputState>({
+    content: '',
+    isEdit: false,
+    commentId: '0',
+  });
+
+  //댓글 수정 클릭 시 input focus 를 위한 ref
+  const commentInputRef = useRef<HTMLInputElement>(null);
+
+  //현재 대댓글 페이지의 부모 댓글을 api 에서 지원하지 않기 때문에 따로 가져옴
   const {
     data: parentCommentsData,
     isError: isParentCommentsDataError,
     error: parentCommentsDataError,
-  } = useFindAllParentCommentAndThreeChildComment(feedId);
+  } = useFindAllParentComment(feedId);
 
   const parentCommentData = parentCommentsData?.pages[0].results.find(
-    (result) => result.commentId === commentId
+    (result) => result.commentId === parentCommentId
   );
 
-  //현재 답댓글 페이지의 답댓글들을 가져옴
+  //현재 대댓글 페이지의 대댓글들을 가져옴
   const {
     data: childrenCommentData,
     isError: isChildrenCommentDataError,
@@ -42,12 +68,24 @@ export default function CommentDetailPage() {
     hasNextPage: hasChildrenCommentNextPage,
     fetchNextPage: fetchChildrenCommentNextPage,
     isFetchingNextPage: isFetchingChildrenCommentNextPage,
-  } = useFindAllChildrenComment(commentId);
+  } = useFindAllChildrenComment(parentCommentId);
 
-  //답댓글 생성 useMutation
-  const { mutate: createCommentMutate } = useCreateChildComment(
+  //대댓글 생성 useMutation
+  const { mutate: createChildCommentMutate } = useCreateChildComment(
     feedId,
-    commentId
+    parentCommentId
+  );
+
+  //댓글 수정 useMutation
+  const { mutate: updateCommentMutate } = useUpdateComment(
+    feedId,
+    selectedComment.commentId
+  );
+
+  //댓글 삭제 useMutation
+  const { mutate: deleteCommentMutate } = useDeleteComment(
+    feedId,
+    selectedComment.commentId
   );
 
   //뒤로가기 핸들러
@@ -55,9 +93,28 @@ export default function CommentDetailPage() {
     router.back();
   };
 
+  //댓글 수정 클릭 핸들러
+  const handleModifyCommentClick = (commentId: string) => {
+    setSelectedComment({ ...selectedComment, commentId, isEdit: true });
+    commentInputRef.current?.focus();
+  };
+
+  //댓글 삭제 클릭 핸들러
+  const handleDeleteCommentClick = (commentId: string) => {
+    setSelectedComment({ ...selectedComment, commentId });
+    setOpenBTSheet(true);
+  };
+
   //등록 버튼 클릭 핸들러
-  const handleSubmitCommentClick = (request: CommentCreateRequest) => {
-    createCommentMutate(request);
+  const handleSubmitCommentClick = (
+    request: CommentCreateRequest | CommentUpdateRequest
+  ) => {
+    if (selectedComment.isEdit) {
+      updateCommentMutate(request);
+      setSelectedComment({ ...selectedComment, isEdit: false });
+    } else {
+      createChildCommentMutate(request);
+    }
   };
 
   //infinite scroll 핸들러
@@ -70,6 +127,12 @@ export default function CommentDetailPage() {
     },
     { threshold: 1 }
   );
+
+  //바텀 시트 확인 핸들러
+  const handleConfirmBTSheet = () => {
+    deleteCommentMutate();
+    setOpenBTSheet(false);
+  };
 
   if (isParentCommentsDataError || isChildrenCommentDataError) {
     return (
@@ -87,31 +150,35 @@ export default function CommentDetailPage() {
       writerProfileImage,
       createdAt,
       updatedAt,
+      isOwner,
     } = parentCommentData;
 
     return (
       <div className="mb-footer overflow-auto scrollbar-hide">
         <AppBar
           leftNode={<BackButton onClick={handleBackButtonClick} />}
-          title={`답댓글 ${childrenCommentData.pages[0].totalCount}`}
+          title={`대댓글 ${childrenCommentData.pages[0].totalCount}`}
           rightNode={<Empty />}
         />
-        <Commment
+        <Comment
           postId={feedId}
-          commentId={commentId}
+          commentId={parentCommentId}
           content={content}
           isDeleted={isDeleted}
           writerNickname={writerNickname}
           writerProfileImage={writerProfileImage}
           createdAt={createdAt}
           updatedAt={updatedAt}
+          isOwner={isOwner}
           isParent={true}
+          handleModifyCommentClick={handleModifyCommentClick}
+          handleDeleteCommentClick={handleDeleteCommentClick}
         />
         <div className="pl-10">
           {childrenCommentData.pages.map((page) => {
             return page.results.map((comment) => {
               return (
-                <Commment
+                <Comment
                   key={comment.commentId}
                   postId={comment.postId}
                   commentId={comment.commentId}
@@ -122,6 +189,9 @@ export default function CommentDetailPage() {
                   createdAt={comment.createdAt}
                   updatedAt={comment.updatedAt}
                   isParent={false}
+                  isOwner={comment.isOwner}
+                  handleModifyCommentClick={handleModifyCommentClick}
+                  handleDeleteCommentClick={handleDeleteCommentClick}
                 />
               );
             });
@@ -133,9 +203,17 @@ export default function CommentDetailPage() {
           )}
         </div>
         <CommentInput
-          commentId={commentId}
+          refObj={commentInputRef}
+          parentCommentId={parentCommentId}
           onClickSubmit={handleSubmitCommentClick}
         />
+        <BottomSheet open={openBTSheet} onDismiss={() => setOpenBTSheet(false)}>
+          <ButtonSheet
+            text="댓글을 삭제하시겠습니까?"
+            onCancel={() => setOpenBTSheet(false)}
+            onConfirm={handleConfirmBTSheet}
+          />
+        </BottomSheet>
       </div>
     );
   }

--- a/packages/climbingweb/pages/feed/[fid]/comments/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/index.tsx
@@ -1,83 +1,97 @@
 import { CommentInput } from 'climbingweb/src/components/Comments/CommentInput';
-import { Comments } from 'climbingweb/src/components/Comments/Comments';
+import { ParentComment } from 'climbingweb/src/components/Comments/Comments';
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
-
-const comments = [
-  {
-    commentId: '1',
-    writerNickName: 'Calvin Hawkins',
-    createAt: '22.01.23·12:34',
-    writerProfileImage:
-      'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-    content:
-      'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ducimus sapiente laudantium natus quam culpa! Iure sit odio obcaecati veritatis error a perferendis doloribus aut laboriosam quis ipsum non, deleniti perspiciatis!',
-    isDeleted: false,
-    children: [
-      {
-        commentId: '4',
-        writerNickName: 'Calvin Hawkins',
-        createAt: '22.01.23·12:34',
-        writerProfileImage:
-          'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-        content:
-          'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ducimus sapiente laudantium natus quam culpa! Iure sit odio obcaecati veritatis error a perferendis doloribus aut laboriosam quis ipsum non, deleniti perspiciatis!',
-        isDeleted: false,
-      },
-      {
-        commentId: '5',
-        writerNickName: 'Calvin Hawkins',
-        createAt: '22.01.23·12:34',
-        writerProfileImage:
-          'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-        content:
-          'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ducimus sapiente laudantium natus quam culpa! Iure sit odio obcaecati veritatis error a perferendis doloribus aut laboriosam quis ipsum non, deleniti perspiciatis!',
-        isDeleted: false,
-      },
-    ],
-  },
-  {
-    commentId: '2',
-    writerNickName: 'Calvin Hawkins',
-    createAt: '22.01.23·12:34',
-    writerProfileImage:
-      'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-    content:
-      'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ducimus sapiente laudantium natus quam culpa! Iure sit odio obcaecati veritatis error a perferendis doloribus aut laboriosam quis ipsum non, deleniti perspiciatis!',
-    isDeleted: false,
-    children: [],
-  },
-  {
-    commentId: 3,
-    writerNickName: 'Calvin Hawkins',
-    createAt: '22.01.23·12:34',
-    writerProfileImage:
-      'https://images.unsplash.com/photo-1491528323818-fdd1faba62cc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-    content:
-      'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ducimus sapiente laudantium natus quam culpa! Iure sit odio obcaecati veritatis error a perferendis doloribus aut laboriosam quis ipsum non, deleniti perspiciatis!',
-    isDeleted: true,
-    children: [],
-  },
-];
+import {
+  BackButton,
+  Empty,
+} from 'climbingweb/src/components/common/AppBar/IconButton';
+import ErrorContent from 'climbingweb/src/components/common/Error/ErrorContent';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
+import {
+  useCreateComment,
+  useFindAllParentCommentAndThreeChildComment,
+} from 'climbingweb/src/hooks/queries/post/queryKey';
+import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
+import { CommentCreateRequest } from 'climbingweb/types/request/post';
+import { useRouter } from 'next/router';
 
 export default function CommentPage() {
-  return (
-    <div className="mb-footer overflow-auto scrollbar-hide">
-      <div>
-        <AppBar title="댓글" />
-        {comments.map((comment) => (
-          <Comments
-            key={comment.commentId}
-            content={comment.content}
-            isDeleted={comment.isDeleted}
-            writerNickName={comment.writerNickName}
-            writerProfileImage={comment.writerProfileImage}
-            createAt={comment.createAt}
-            replies={comment.children}
-          />
-        ))}
-        <div className="h-24 w-full"></div>
-      </div>
-      <CommentInput />
-    </div>
+  const router = useRouter();
+  const { fid } = router.query;
+  const feedId = fid as string;
+
+  //현재 댓글 페이지의 댓글들을 가져옴
+  const {
+    data: commentData,
+    isError: isCommentDataError,
+    error: commentDataError,
+    hasNextPage: hasCommentNextPage,
+    fetchNextPage: fetchCommentNextPage,
+    isFetchingNextPage: isFetchingCommentNextPage,
+  } = useFindAllParentCommentAndThreeChildComment(feedId);
+
+  //댓글 생성 useMutation
+  const { mutate: createCommentMutate } = useCreateComment(feedId);
+
+  //뒤로가기 핸들러
+  const handleBackButtonClick = () => {
+    router.back();
+  };
+
+  //등록 버튼 클릭 핸들러
+  const handleSubmitComment = (request: CommentCreateRequest) => {
+    createCommentMutate(request);
+  };
+
+  //infinite scroll 핸들러
+  const target = useIntersectionObserver(
+    async (entry, observer) => {
+      observer.unobserve(entry.target);
+      if (hasCommentNextPage) {
+        fetchCommentNextPage();
+      }
+    },
+    { threshold: 1 }
   );
+
+  if (isCommentDataError) {
+    return <ErrorContent error={commentDataError} />;
+  }
+
+  if (commentData)
+    return (
+      <div className="mb-footer overflow-auto scrollbar-hide">
+        <div className="mb-footer">
+          <AppBar
+            leftNode={<BackButton onClick={handleBackButtonClick} />}
+            title={`댓글 ${commentData.pages[0].totalCount}`}
+            rightNode={<Empty />}
+          />
+          {commentData.pages.map((page) =>
+            page.results.map((comment) => (
+              <ParentComment
+                key={comment.commentId}
+                postId={comment.postId}
+                commentId={comment.commentId}
+                content={comment.content}
+                isDeleted={comment.isDeleted}
+                writerNickname={comment.writerNickname}
+                writerProfileImage={comment.writerProfileImage}
+                createdAt={comment.createdAt}
+                updatedAt={comment.updatedAt}
+                replies={comment.children}
+              />
+            ))
+          )}
+          {!isFetchingCommentNextPage ? (
+            <div className="h-[1px]" ref={target}></div>
+          ) : (
+            <Loading />
+          )}
+        </div>
+        <CommentInput onClickSubmit={handleSubmitComment} />
+      </div>
+    );
+
+  return <Loading />;
 }

--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -80,7 +80,7 @@ const Home: NextPage = () => {
           ));
         })}
         {!isFetchingPosts && !isFetchingLaonPosts ? (
-          <div className="h-[1px] bg-slate-300" ref={target}></div>
+          <div className="h-[1px]" ref={target}></div>
         ) : (
           <Loading />
         )}

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterPost.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterPost.tsx
@@ -61,7 +61,7 @@ export const CenterPost = ({ centerId }: CenterPostsProps) => {
           })}
         </div>
         {!isFetchingNextPage ? (
-          <div className="h-[1px] bg-slate-300" ref={target}></div>
+          <div className="h-[1px]" ref={target}></div>
         ) : (
           <Loading />
         )}

--- a/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterReview.tsx
+++ b/packages/climbingweb/src/components/CenterInfo/CenterDetailInfo/CenterReview.tsx
@@ -102,7 +102,7 @@ export const CenterReview = ({ id }: ReviewProps) => {
               })}
             </div>
             {!isFetchingNextPage ? (
-              <div className="h-[1px] bg-slate-300" ref={target}></div>
+              <div className="h-[1px]" ref={target}></div>
             ) : (
               <Loading />
             )}

--- a/packages/climbingweb/src/components/Comments/CommentInput.tsx
+++ b/packages/climbingweb/src/components/Comments/CommentInput.tsx
@@ -18,11 +18,7 @@ export const CommentInput = ({
           ref={refObj}
           className="w-full p-4"
           type="text"
-          placeholder={
-            parentCommentId
-              ? '대댓글을 입력해 주세요.'
-              : '댓글을 입력해 주세요.'
-          }
+          placeholder={'댓글을 입력해 주세요.'}
         />
         <button
           className="bg-white min-w-max text-purple-500 rounded-lg p-4 mx-1"

--- a/packages/climbingweb/src/components/Comments/CommentInput.tsx
+++ b/packages/climbingweb/src/components/Comments/CommentInput.tsx
@@ -1,10 +1,43 @@
+import { CommentCreateRequest } from 'climbingweb/types/request/post';
+import { useRef } from 'react';
 
+interface CommentInputProps {
+  commentId?: string;
+  onClickSubmit: (request: CommentCreateRequest) => void;
+}
 
-export const CommentInput = ({ }) => {
-
-    return (
-        <div className='bg-gray-100 w-full h-24 flex flex-col p-4 fixed bottom-0'>
-            <input className="w-full rounded-lg p-4 bg-white" type="text" placeholder='댓글을 입력해 주세요.' />
-        </div>
-    );
+export const CommentInput = ({
+  commentId,
+  onClickSubmit,
+}: CommentInputProps) => {
+  const ref = useRef<HTMLInputElement>(null);
+  return (
+    <div className="bg-gray-100 w-full h-24 flex p-4 fixed bottom-0 mb-footer">
+      <div className="w-full bg-white rounded-lg flex">
+        <input
+          ref={ref}
+          className="w-full p-4"
+          type="text"
+          placeholder={
+            commentId ? '답댓글을 입력해 주세요.' : '댓글을 입력해 주세요.'
+          }
+        />
+        <button
+          className="bg-white min-w-max text-purple-500 rounded-lg p-4 mx-1"
+          onClick={() => {
+            const content = ref.current?.value;
+            if (content) {
+              onClickSubmit({
+                parentCommentId: commentId,
+                content: ref.current?.value,
+              });
+              ref.current.value = '';
+            }
+          }}
+        >
+          등록
+        </button>
+      </div>
+    </div>
+  );
 };

--- a/packages/climbingweb/src/components/Comments/CommentInput.tsx
+++ b/packages/climbingweb/src/components/Comments/CommentInput.tsx
@@ -1,37 +1,39 @@
 import { CommentCreateRequest } from 'climbingweb/types/request/post';
-import { useRef } from 'react';
 
 interface CommentInputProps {
-  commentId?: string;
+  refObj: React.RefObject<HTMLInputElement>;
+  parentCommentId?: string;
   onClickSubmit: (request: CommentCreateRequest) => void;
 }
 
 export const CommentInput = ({
-  commentId,
+  refObj,
+  parentCommentId,
   onClickSubmit,
 }: CommentInputProps) => {
-  const ref = useRef<HTMLInputElement>(null);
   return (
     <div className="bg-gray-100 w-full h-24 flex p-4 fixed bottom-0 mb-footer">
       <div className="w-full bg-white rounded-lg flex">
         <input
-          ref={ref}
+          ref={refObj}
           className="w-full p-4"
           type="text"
           placeholder={
-            commentId ? '답댓글을 입력해 주세요.' : '댓글을 입력해 주세요.'
+            parentCommentId
+              ? '대댓글을 입력해 주세요.'
+              : '댓글을 입력해 주세요.'
           }
         />
         <button
           className="bg-white min-w-max text-purple-500 rounded-lg p-4 mx-1"
           onClick={() => {
-            const content = ref.current?.value;
+            const content = refObj.current?.value;
             if (content) {
               onClickSubmit({
-                parentCommentId: commentId,
-                content: ref.current?.value,
+                parentCommentId: parentCommentId,
+                content: refObj.current?.value,
               });
-              ref.current.value = '';
+              refObj.current.value = '';
             }
           }}
         >

--- a/packages/climbingweb/src/components/Comments/Comments.tsx
+++ b/packages/climbingweb/src/components/Comments/Comments.tsx
@@ -1,5 +1,3 @@
-import { Pagination } from 'climbingweb/types/common';
-import { ChildCommentResponse } from 'climbingweb/types/response/post';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 
@@ -12,12 +10,15 @@ interface ParentCommentProps {
   writerProfileImage: string;
   createdAt: string;
   updatedAt?: string;
-  replies?: Pagination<ChildCommentResponse>;
+  childrenCommentCount: number;
+  isOwner?: boolean;
+  handleModifyCommentClick: (commentId: string) => void;
+  handleDeleteCommentClick: (commentId: string) => void;
 }
 
 interface CommentProps {
   postId: string;
-  commentId?: string;
+  commentId: string;
   content: string;
   isDeleted: boolean;
   writerNickname: string;
@@ -25,9 +26,12 @@ interface CommentProps {
   createdAt: string;
   updatedAt?: string;
   isParent: boolean;
+  isOwner?: boolean;
+  handleModifyCommentClick: (commentId: string) => void;
+  handleDeleteCommentClick: (commentId: string) => void;
 }
 
-export const Commment = ({
+export const Comment = ({
   postId,
   commentId,
   content,
@@ -37,6 +41,9 @@ export const Commment = ({
   createdAt,
   updatedAt,
   isParent,
+  isOwner,
+  handleModifyCommentClick,
+  handleDeleteCommentClick,
 }: CommentProps) => {
   const router = useRouter();
   const hanedleCreateChildComment = () => {
@@ -65,8 +72,24 @@ export const Commment = ({
                   className="hover:text-black"
                   onClick={hanedleCreateChildComment}
                 >
-                  ·답댓글 달기
+                  ·대댓글 달기
                 </span>
+              )}
+              {isOwner && (
+                <>
+                  <span
+                    className="hover:text-black"
+                    onClick={() => handleModifyCommentClick(commentId)}
+                  >
+                    ·수정
+                  </span>
+                  <span
+                    className="hover:text-black"
+                    onClick={() => handleDeleteCommentClick(commentId)}
+                  >
+                    ·삭제
+                  </span>
+                </>
               )}
             </p>
           </div>
@@ -90,9 +113,11 @@ export function ParentComment({
   writerProfileImage,
   createdAt,
   updatedAt,
-  replies,
+  childrenCommentCount,
+  isOwner,
+  handleModifyCommentClick,
+  handleDeleteCommentClick,
 }: ParentCommentProps) {
-  const moreCommentCount = replies ? replies.totalCount - 3 : 0;
   const router = useRouter();
 
   const handleMoreCommentClick = () => {
@@ -101,7 +126,7 @@ export function ParentComment({
 
   return (
     <>
-      <Commment
+      <Comment
         postId={postId}
         commentId={commentId}
         content={content}
@@ -111,33 +136,18 @@ export function ParentComment({
         createdAt={createdAt}
         updatedAt={updatedAt}
         isParent={true}
+        isOwner={isOwner}
+        handleModifyCommentClick={() => handleModifyCommentClick(commentId)}
+        handleDeleteCommentClick={() => handleDeleteCommentClick(commentId)}
       />
-      {replies && (
-        <div className="pl-10">
-          {replies.results.map((reply) => (
-            <Commment
-              key={reply.commentId}
-              postId={postId}
-              commentId={reply.commentId}
-              content={reply.content}
-              isDeleted={reply.isDeleted}
-              writerNickname={reply.writerNickname}
-              writerProfileImage={reply.writerProfileImage}
-              createdAt={reply.createdAt}
-              updatedAt={reply.updatedAt}
-              isParent={false}
-            />
-          ))}
-          {moreCommentCount > 0 ? (
-            <div className="flex flex-row h-10 content-center items-center">
-              <div className="bg-gray-400 h-px w-8 mr-3" />
-              <span className="text-gray-400" onClick={handleMoreCommentClick}>
-                답댓글 {moreCommentCount}개 더 보기
-              </span>
-            </div>
-          ) : null}
+      {childrenCommentCount > 0 ? (
+        <div className="flex flex-row pl-10 h-10 content-center items-center">
+          <div className="bg-gray-400 h-px w-8 mr-3" />
+          <span className="text-gray-400" onClick={handleMoreCommentClick}>
+            대댓글 {childrenCommentCount}개 더 보기
+          </span>
         </div>
-      )}
+      ) : null}
     </>
   );
 }

--- a/packages/climbingweb/src/components/Comments/Comments.tsx
+++ b/packages/climbingweb/src/components/Comments/Comments.tsx
@@ -44,7 +44,7 @@ export const Commment = ({
   };
 
   return (
-    <div className="w-screen flex flex-row">
+    <div className="w-screen flex flex-row mx-5">
       <div className="flex flex-row py-4 gap-2">
         <div className="h-10 w-10 relative">
           <Image
@@ -71,7 +71,7 @@ export const Commment = ({
             </p>
           </div>
           <div className="w-screen">
-            <p className="text-sm line-clamp-3 ">
+            <p className="text-sm line-clamp-3 inline">
               {isDeleted ? '삭제된 게시글 입니다' : content}
             </p>
           </div>
@@ -132,7 +132,7 @@ export function ParentComment({
             <div className="flex flex-row h-10 content-center items-center">
               <div className="bg-gray-400 h-px w-8 mr-3" />
               <span className="text-gray-400" onClick={handleMoreCommentClick}>
-                대댓글 {moreCommentCount}개 더 보기
+                답댓글 {moreCommentCount}개 더 보기
               </span>
             </div>
           ) : null}

--- a/packages/climbingweb/src/components/Comments/Comments.tsx
+++ b/packages/climbingweb/src/components/Comments/Comments.tsx
@@ -1,102 +1,143 @@
+import { Pagination } from 'climbingweb/types/common';
+import { ChildCommentResponse } from 'climbingweb/types/response/post';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 
-interface Props {
-    commentId?: string;
-    content: string;
-    isDeleted: boolean;
-    postId?: string;
-    writerNickName: string;
-    writerProfileImage: string;
-    createAt?: string;
-    updateAt?: string;
-    replies?: {
-        commentId?: string;
-        content: string;
-        isDeleted: boolean;
-        postId?: string;
-        writerNickName: string;
-        writerProfileImage: string;
-        createAt?: string;
-        updateAt?: string;
-    }[];
+interface ParentCommentProps {
+  postId: string;
+  commentId: string;
+  content: string;
+  isDeleted: boolean;
+  writerNickname: string;
+  writerProfileImage: string;
+  createdAt: string;
+  updatedAt?: string;
+  replies?: Pagination<ChildCommentResponse>;
 }
 
+interface CommentProps {
+  postId: string;
+  commentId?: string;
+  content: string;
+  isDeleted: boolean;
+  writerNickname: string;
+  writerProfileImage: string;
+  createdAt: string;
+  updatedAt?: string;
+  isParent: boolean;
+}
 
-const Commment = ({
-    content,
-    isDeleted,
-    writerNickName,
-    writerProfileImage,
-    createAt,
-    updateAt,
-    replies,
-}: Props) => {
-    const isReply = replies ? true : false;
+export const Commment = ({
+  postId,
+  commentId,
+  content,
+  isDeleted,
+  writerNickname,
+  writerProfileImage,
+  createdAt,
+  updatedAt,
+  isParent,
+}: CommentProps) => {
+  const router = useRouter();
+  const hanedleCreateChildComment = () => {
+    router.push(`/feed/${postId}/comments/${commentId}`);
+  };
 
-    return (
-        <div className='w-screen flex flex-row'>
-            <div className='flex flex-row py-4 gap-2'>
-                <div className='h-10 w-10 relative'>
-                    <Image className='rounded-full' layout="fill" objectFit='cover' src={writerProfileImage} alt="comment" />
-                </div>
-                <div className='w-screen gap-2'>
-                    <div className='h-10'>
-                        <p className='text-sm font-bold'>{writerNickName}</p>
-                        <p className='text-gray-400 '>{updateAt ? updateAt : createAt} {isReply && <span className='hover:text-black' onClick={() => { }}>·답댓글 달기</span>}</p>
-                    </div>
-                    <div className='w-screen'>
-                        <p className='text-sm line-clamp-3 '>{isDeleted ? '삭제된 게시글 입니다' : content}</p>
-                    </div>
-                </div>
-            </div>
-        </div >
-    );
+  return (
+    <div className="w-screen flex flex-row">
+      <div className="flex flex-row py-4 gap-2">
+        <div className="h-10 w-10 relative">
+          <Image
+            className="rounded-full"
+            layout="fill"
+            objectFit="cover"
+            src={writerProfileImage}
+            alt="comment"
+          />
+        </div>
+        <div className="w-screen gap-2">
+          <div className="h-10">
+            <p className="text-sm font-bold">{writerNickname}</p>
+            <p className="text-gray-400 ">
+              {updatedAt ? updatedAt : createdAt}
+              {isParent && (
+                <span
+                  className="hover:text-black"
+                  onClick={hanedleCreateChildComment}
+                >
+                  ·답댓글 달기
+                </span>
+              )}
+            </p>
+          </div>
+          <div className="w-screen">
+            <p className="text-sm line-clamp-3 ">
+              {isDeleted ? '삭제된 게시글 입니다' : content}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
-export function Comments({
-    content,
-    isDeleted,
-    writerNickName,
-    writerProfileImage,
-    createAt,
-    updateAt,
-    replies,
-}: Props) {
+export function ParentComment({
+  postId,
+  commentId,
+  content,
+  isDeleted,
+  writerNickname,
+  writerProfileImage,
+  createdAt,
+  updatedAt,
+  replies,
+}: ParentCommentProps) {
+  const moreCommentCount = replies ? replies.totalCount - 3 : 0;
+  const router = useRouter();
 
-    const count = replies ? replies.length - 3 : 0;
+  const handleMoreCommentClick = () => {
+    router.push(`/feed/${postId}/comments/${commentId}`);
+  };
 
-    return (
-        <>
+  return (
+    <>
+      <Commment
+        postId={postId}
+        commentId={commentId}
+        content={content}
+        isDeleted={isDeleted}
+        writerNickname={writerNickname}
+        writerProfileImage={writerProfileImage}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        isParent={true}
+      />
+      {replies && (
+        <div className="pl-10">
+          {replies.results.map((reply) => (
             <Commment
-                content={content}
-                isDeleted={isDeleted}
-                writerNickName={writerNickName}
-                writerProfileImage={writerProfileImage}
-                createAt={createAt}
-                updateAt={updateAt}
-                replies={replies}
+              key={reply.commentId}
+              postId={postId}
+              commentId={reply.commentId}
+              content={reply.content}
+              isDeleted={reply.isDeleted}
+              writerNickname={reply.writerNickname}
+              writerProfileImage={reply.writerProfileImage}
+              createdAt={reply.createdAt}
+              updatedAt={reply.updatedAt}
+              isParent={false}
             />
-            {
-                replies && <div className='pl-10' >
-                    {replies.map(reply =>
-                        <Commment
-                            key={reply.commentId}
-                            content={reply.content}
-                            isDeleted={reply.isDeleted}
-                            writerNickName={reply.writerNickName}
-                            writerProfileImage={reply.writerProfileImage}
-                            createAt={reply.createAt}
-                            updateAt={reply.updateAt}
-                        />
-                    )}
-                    {count > 0 &&
-                        <div className='flex flex-row h-10 content-center items-center'>
-                            <div className='bg-gray-400 h-px w-8 mr-3' />
-                            <span className='text-gray-400'>대댓글 {count}개 더 보기</span>
-                        </div>}
-                </div>
-            }
-        </>
-    );
-
+          ))}
+          {moreCommentCount > 0 ? (
+            <div className="flex flex-row h-10 content-center items-center">
+              <div className="bg-gray-400 h-px w-8 mr-3" />
+              <span className="text-gray-400" onClick={handleMoreCommentClick}>
+                대댓글 {moreCommentCount}개 더 보기
+              </span>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </>
+  );
 }

--- a/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/HomeFeed.tsx
@@ -14,7 +14,7 @@ import { useRouter } from 'next/router';
 import {
   useCreateLike,
   useDeleteLike,
-  useFindAllParentCommentAndThreeChildComment,
+  useFindAllParentComment,
 } from 'climbingweb/src/hooks/queries/post/queryKey';
 
 interface HomeFeedProps {
@@ -31,7 +31,7 @@ const HomeFeed = ({ postData }: HomeFeedProps) => {
     data: commentData,
     isError: isCommentError,
     error: commentError,
-  } = useFindAllParentCommentAndThreeChildComment(postData.postId);
+  } = useFindAllParentComment(postData.postId);
 
   //좋아요 추가 useMutation
   const { mutate: createLikeMutate } = useCreateLike(postData.postId);

--- a/packages/climbingweb/src/hooks/queries/post/queries.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queries.ts
@@ -1,12 +1,16 @@
+import {
+  ChildCommentResponse,
+  CommentResponse,
+} from './../../../../types/response/post/index.d';
 import axios from 'axios';
 import { Pagination } from 'climbingweb/types/common';
 import {
   CommentCreateRequest,
+  CommentUpdateRequest,
   PostCreateRequest,
   PostReportRequest,
 } from 'climbingweb/types/request/post';
 import {
-  ChildCommentResponse,
   CommentFindResponse,
   LikeResponse,
   PostDetailResponse,
@@ -84,18 +88,15 @@ export const deleteLike = async (postId: string) => {
 };
 
 /**
- * GET /api​/v1​/posts​/comment​/{parentId}​/children api query 함수
+ * GET /api/v1/posts/{postId}/comment api query 함수
  *
- * @param commentId 모든 대댓글을 확인 할 commentId
+ * @param postId 모든 댓글을 확인 할 postId
  * @returns axiosResponse.data
  */
-export const findAllChildrenComment = async (
-  parentId: string,
-  pageParam = 0
-) => {
+export const findAllParentComment = async (postId: string, pageParam = 0) => {
   try {
-    const { data } = await axios.get<Pagination<ChildCommentResponse>>(
-      `/posts/comment/${parentId}/children`,
+    const { data } = await axios.get<Pagination<CommentFindResponse>>(
+      `/posts/${postId}/comment`,
       {
         params: {
           page: pageParam,
@@ -109,18 +110,18 @@ export const findAllChildrenComment = async (
 };
 
 /**
- * GET /api/v1/posts/{postId}/comment api query 함수
+ * GET /api​/v1​/posts​/comment​/{parentId}​/children api query 함수
  *
- * @param postId 모든 댓글을 확인 할 postId
+ * @param parentId 모든 대댓글을 확인 할 commentId
  * @returns axiosResponse.data
  */
-export const findAllParentCommentAndThreeChildComment = async (
-  postId: string,
+export const findAllChildrenComment = async (
+  parentId: string,
   pageParam = 0
 ) => {
   try {
-    const { data } = await axios.get<Pagination<CommentFindResponse>>(
-      `/posts/${postId}/comment`,
+    const { data } = await axios.get<Pagination<ChildCommentResponse>>(
+      `/posts/comment/${parentId}/children`,
       {
         params: {
           page: pageParam,
@@ -182,6 +183,45 @@ export const createComment = async (
     const { data } = await axios.post<CommentCreateRequest>(
       `/posts/${postId}/comment`,
       commentCreateRequest
+    );
+    return data;
+  } catch (error: any) {
+    throw error.response.data;
+  }
+};
+
+/**
+ * PUT /api/v1/posts/comment/{commentId} api query 함수
+ *
+ * @param commentId 수정할 댓글의 id
+ * @param commentUpdateRequest 수정할 댓글 내용
+ * @returns axiosResponse.data
+ */
+export const updateComment = async (
+  commentId: string,
+  commentUpdateRequest: CommentUpdateRequest
+) => {
+  try {
+    const { data } = await axios.put<CommentUpdateRequest>(
+      `/posts/comment/${commentId}`,
+      commentUpdateRequest
+    );
+    return data;
+  } catch (error: any) {
+    throw error.response.data;
+  }
+};
+
+/**
+ * DELETE /api/v1/posts/comment/{commentId} api query 함수
+ *
+ * @param commentId 삭제할 댓글의 id
+ * @returns axiosResponse.data
+ */
+export const deleteComment = async (commentId: string) => {
+  try {
+    const { data } = await axios.delete<CommentResponse>(
+      `/posts/comment/${commentId}`
     );
     return data;
   } catch (error: any) {

--- a/packages/climbingweb/src/hooks/queries/post/queries.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queries.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Pagination } from 'climbingweb/types/common';
 import {
+  CommentCreateRequest,
   PostCreateRequest,
   PostReportRequest,
 } from 'climbingweb/types/request/post';
@@ -89,12 +90,12 @@ export const deleteLike = async (postId: string) => {
  * @returns axiosResponse.data
  */
 export const findAllChildrenComment = async (
-  commentId: string,
+  parentId: string,
   pageParam = 0
 ) => {
   try {
     const { data } = await axios.get<Pagination<ChildCommentResponse>>(
-      `/posts/${commentId}/comment`,
+      `/posts/comment/${parentId}/children`,
       {
         params: {
           page: pageParam,
@@ -160,6 +161,28 @@ export const getPosts = async (pageParam = 0) => {
         page: pageParam,
       },
     });
+    return data;
+  } catch (error: any) {
+    throw error.response.data;
+  }
+};
+
+/**
+ *  POST /api/v1/posts/{postId}/comment api query 함수
+ *
+ * @param postId 댓글을 달 게시글의 id
+ * @param commentCreateRequest 댓글 내용, 대 댓글일 경우 commentId 까지
+ * @returns axiosResponse.data
+ */
+export const createComment = async (
+  postId: string,
+  commentCreateRequest: CommentCreateRequest
+) => {
+  try {
+    const { data } = await axios.post<CommentCreateRequest>(
+      `/posts/${postId}/comment`,
+      commentCreateRequest
+    );
     return data;
   } catch (error: any) {
     throw error.response.data;

--- a/packages/climbingweb/types/request/post/index.d.ts
+++ b/packages/climbingweb/types/request/post/index.d.ts
@@ -28,6 +28,10 @@ export interface PostReportRequest {
 }
 
 export interface CommentCreateRequest {
-  content?: string;
+  content: string;
   parentCommentId?: string;
+}
+
+export interface CommentUpdateRequest {
+  content: string;
 }

--- a/packages/climbingweb/types/request/post/index.d.ts
+++ b/packages/climbingweb/types/request/post/index.d.ts
@@ -27,11 +27,7 @@ export interface PostReportRequest {
   reportType: '부적절한 게시글' | '부적절한 닉네임' | '잘못된 암장 선택';
 }
 
-export interface CommentRequest {
-  content: string;
+export interface CommentCreateRequest {
+  content?: string;
   parentCommentId?: string;
-}
-
-export interface CommentRequest {
-  content: string;
 }

--- a/packages/climbingweb/types/response/post/index.d.ts
+++ b/packages/climbingweb/types/response/post/index.d.ts
@@ -1,5 +1,3 @@
-import { Pagination } from 'climbingweb/types/common';
-
 export interface PostResponse {
   centerId: string;
   centerName: string;
@@ -22,6 +20,7 @@ export interface PostDetailResponse {
   contentsList: string[];
   createdAt: string;
   isLike: boolean;
+  isOwner: boolean;
   likeCount: number;
   postId: string;
   userNickname: string;
@@ -39,11 +38,12 @@ export interface ClimbingHistoryResponse {
 }
 
 export interface CommentFindResponse {
-  children: Pagination<ChildCommentResponse>;
+  childrenCommentCount: number;
   commentId: string;
   content: string;
   createdAt: string;
   isDeleted: boolean;
+  isOwner: boolean;
   postId: string;
   updatedAt: string;
   writerNickname: string;
@@ -59,6 +59,7 @@ export interface ChildCommentResponse {
   updatedAt: string;
   writerNickname: string;
   writerProfileImage: string;
+  isOwner?: boolean;
 }
 
 export interface LikeFindResponse {

--- a/packages/climbingweb/types/response/post/index.d.ts
+++ b/packages/climbingweb/types/response/post/index.d.ts
@@ -39,7 +39,7 @@ export interface ClimbingHistoryResponse {
 }
 
 export interface CommentFindResponse {
-  children: Pagination<ChildCommentResponse[]>;
+  children: Pagination<ChildCommentResponse>;
   commentId: string;
   content: string;
   createdAt: string;


### PR DESCRIPTION
## Description
feat: 댓글 페이지 및 대댓글 페이지 기능 추가

## Changes detail

- 댓글 페이지
- 대댓글 페이지 추가
  1. /feed/[fid]/comments/[cid] 로 라우팅
  2. 대댓글 페이지 마크업 추가
  3. 대댓글 페이지 백엔드 로직 추가
  대댓글 CUD 추가
  ![cocommentTest](https://user-images.githubusercontent.com/37992140/204255797-7c1cd585-0dd4-410b-a250-e2330d2d7552.gif)
  placeholder 수정 했음! (댓글을 입력해주세요)
- 댓글 페이지 리팩터링
  2. 댓글 페이지 백엔드 로직 추가
  댓글 CUD 추가
- infiniteScroll 을 위한 intersectionObserver target element 투명하게 변경
  1. /home
  2. <CenterCenterPost />
  3. <CenterReview />
- <CommentInput /> 리팩터링
  1. useRef 를 이용해서 input value 를 state 로 관리하지 않게 변경해 성능 향상 도모
  2. CSS 조금 더 자연스럽도록 변경
  3. 등록 버튼 추가 및 기능 추가
- Comment 관련 컴포넌트 리팩터링
  1. <Comment /> 리팩터링 
    1. 수정 삭제 기능 추가
  2. <ParentComment /> 추가
    1. 대댓글 더 볼 수 있도록 하는 라우팅 기능 포함
- post 컨트롤러 query 관련 파일 변경
  1. queries.ts 변경
     - 백엔드 api 변경 대응
       - findAllParentCommentAndThreeChildComment 삭제
       - findAllParentComment 와 findAllChildComment 추가
     - 백엔드 api 추가
       - updateComment, deleteComment 추가
  2. queryKey.ts 변경
     - 백엔드 api 변경 대응
       - useFindAllParentCommentAndThreeChildComment 삭제
       - useFindAllParentComment 와 useFindAllChildComment 추가
     - 백엔드 api 추가
       - useUpdateComment, useDeleteComment 추가
  3. postQueries 객체 구조 변경
    - childrenComment fetch 해오는 data 들은 postId 에 종속 되어 있을 필요가 없으므로 따로 분리
- 백엔드 dto interface 변경
  - CommentRequest 가 같은 이름에 다른 key 를 가지고 있던 현상 수정하여, CommentCreateRequest, CommentUpdateRequest 추가
  - 백엔드에서 isOwner 기능 추가 지원으로 CommentFindResponse, PostResponse key 값 변경(isOwner key 추가)
    - CommentFindResponse 의 dto 변경으로 children key 이름 및 속성 변경 (대댓글 내용에서 대댓글 갯수로 변경)
 
### Checklist

- [ ] Test case
- [ ] End of work
