### PR TITLE
fix: UserHead 컴포넌트 apeIndex 표기 오류 수정

### DIFF
--- a/packages/climbingweb/src/components/User/UserHead.tsx
+++ b/packages/climbingweb/src/components/User/UserHead.tsx
@@ -79,7 +79,7 @@ export const UserHead = ({
           </p>
           <p className="flex w-full justify-between">
             <span>Ape Index</span>
-            <span>+{apeIndex}</span>
+            <span>{apeIndex > 0 ? `+${apeIndex}` : apeIndex}</span>
           </p>
         </div>
       ) : null}


### PR DESCRIPTION
## Changes detail
fix: UserHead 컴포넌트 apeIndex 표기 오류 수정

- UserHead 컴포넌트에 apeIndex 가 - 값 일 경우 + 가 같이 보이던 현상 수정

### Checklist

- [ ] Test case
- [ ] End of work
