### PR TITLE
fix: 개인페이지 라우팅 변경

### DIFF
--- a/packages/climbingweb/src/components/HomeFeed/FeedHeader/FeedHeader.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/FeedHeader/FeedHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import OptionDotImg from 'climbingweb/src/assets/option_gray800.svg';
 import { ProfileImage } from '../../common/profileImage/ProfileImage';
+import { useRouter } from 'next/router';
 
 interface FeedHeaderProps {
   userImage: string;
@@ -15,12 +16,14 @@ const FeedHeader = ({
   userLocation,
   handleOptionDotClick,
 }: FeedHeaderProps) => {
+  const router = useRouter();
+  const handleProfileClick = () => {
+    router.push(`/users/name/${userName}`);
+  };
   return (
     <header className={'flex w-full h-[56px] my-1 justify-between'}>
-      <div className={'flex items-center'}>
-        <div className={'ml-4 mr-2'}>
-          <ProfileImage src={userImage} />
-        </div>
+      <div className={'flex items-center'} onClick={handleProfileClick}>
+        <ProfileImage src={userImage} />
         <div>
           <p className={'text-sm'}>{userName}</p>
           <p className={'text-sm text-gray-600'}>{userLocation}</p>

--- a/packages/climbingweb/src/components/User/UserFeed.tsx
+++ b/packages/climbingweb/src/components/User/UserFeed.tsx
@@ -1,17 +1,33 @@
 import { ClimbingHistoryResponse } from 'climbingweb/types/response/post';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import React from 'react';
 import MiniHold from './MiniHold';
 
 interface UserFeedProps {
+  postId: string;
   centerName: string;
   image: string;
   climbingHistories: ClimbingHistoryResponse[];
 }
 
-const UserFeed = ({ centerName, image, climbingHistories }: UserFeedProps) => {
+const UserFeed = ({
+  postId,
+  centerName,
+  image,
+  climbingHistories,
+}: UserFeedProps) => {
+  const router = useRouter();
+
+  const handleFeedClick = () => {
+    router.push(`/feed/${postId}`);
+  };
+
   return (
-    <div className="flex flex-col my-1 mr-2 pb-3 rounded-xl shadow-lg max-w-[160px] h-[200px]">
+    <div
+      className="flex flex-col my-1 mr-2 pb-3 rounded-xl shadow-lg max-w-[160px] h-[200px]"
+      onClick={handleFeedClick}
+    >
       <Image
         src={image}
         alt={'UserFeedImage'}

--- a/packages/climbingweb/src/components/User/UserFeedList.tsx
+++ b/packages/climbingweb/src/components/User/UserFeedList.tsx
@@ -21,6 +21,7 @@ const UserFeedList = ({
       page.results.map((result, rIndex) => (
         <UserFeed
           key={`userPost${pIndex}${rIndex}`}
+          postId={result.postId}
           centerName={result.centerName}
           image={result.thumbnailUrl}
           climbingHistories={result.climbingHistories}

--- a/packages/climbingweb/src/components/common/profileImage/ProfileImage.tsx
+++ b/packages/climbingweb/src/components/common/profileImage/ProfileImage.tsx
@@ -14,12 +14,13 @@ export const ProfileImage = ({ src, icon, onClickIcon }: ProfileProps) => {
     <div className="w-16 relative">
       <div className="w-15 h-15 rounded-xl relative">
         {src ? (
-          <div className="w-16 h-16">
+          <div className="w-16 h-16 flex items-center justify-center">
             <Image
               className="relative rounded-full"
               src={src}
-              layout="fill"
               alt="profile"
+              height={40}
+              width={40}
             />
           </div>
         ) : (

--- a/packages/climbingweb/src/hooks/queries/center/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/center/queryKey.ts
@@ -27,18 +27,14 @@ export const centerQueries = createQueryKeys('centers', {
     queryKey: [option],
     queryFn: () => getCenterList(option),
   }),
-  search: (name: string) => {
-    return {
-      queryKey: [name],
-      queryFn: () => searchCenter(name),
-    };
-  },
-  searchName: (centerName: string) => {
-    return {
-      queryKey: [centerName],
-      queryFn: () => searchCenterName(centerName),
-    };
-  },
+  search: (name: string) => ({
+    queryKey: [name],
+    queryFn: () => searchCenter(name),
+  }),
+  searchName: (centerName: string) => ({
+    queryKey: [centerName],
+    queryFn: () => searchCenterName(centerName),
+  }),
   detail: (centerId: string) => ({
     queryKey: [centerId],
     queryFn: () => findCenter(centerId),

--- a/packages/climbingweb/types/response/center/index.d.ts
+++ b/packages/climbingweb/types/response/center/index.d.ts
@@ -214,3 +214,8 @@ export interface ReviewResponse {
  * GET /api/v1/centers/search
  * 특이사항: Pagination«CenterPreviewResponseDto»
  */
+
+export interface UserCenterPreviewResponse {
+  centerImage: string;
+  centerName: string;
+}

--- a/packages/climbingweb/types/response/user/index.d.ts
+++ b/packages/climbingweb/types/response/user/index.d.ts
@@ -1,4 +1,3 @@
-import { CenterPreviewResponse } from '../center/index';
 import { ClimbingHistoryResponse } from 'climbingweb/types/response/post';
 
 export interface BlockUserFindResponse {
@@ -45,7 +44,7 @@ export interface UserDetailResponse {
 }
 
 export interface CenterClimbingHistoryResponse {
-  center: CenterPreviewResponse;
+  center: UserCenterPreviewResponse;
   climbingHistories: ClimbingHistoryResponse[];
 }
 


### PR DESCRIPTION
## Description
개인 페이지 라우팅 추가

## Changes detail

- 피드 헤더 클릭 시 라우팅 되도록 함수 추가
  - 관련 컴포넌트 : FeedHeader
- 개인 페이지 게시물 피드 클릭 시 라우팅 되도록 함수 추가
  - 관련 컴포넌트 : UserFeed, UserFeedList
- 개인 프로필 이미지 크기 wireframe 에 맞게 수정
- center 관련 QueryKey 코드 일관성 있게 변경
- UserCenterPreviewResponse 인터페이스 누락 된 것 추가 및  연관 인터페이스 수정 (CenterClimbingHistoryResponse)

### Checklist

- [ ] Test case
- [ ] End of work
