### PR TITLE
feat: 포스트 이미지 업로드 구현 

### DIFF
--- a/packages/climbingweb/pages/feed/create/index.tsx
+++ b/packages/climbingweb/pages/feed/create/index.tsx
@@ -14,7 +14,6 @@ import {
 } from 'climbingweb/src/hooks/queries/post/queryKey';
 import { useCreatePostForm } from 'climbingweb/src/hooks/useCreatePostForm';
 import Loading from 'climbingweb/src/components/common/Loading/Loading';
-import { useRouter } from 'next/router';
 
 export default function CreatePostPage() {
   const [page, setPage] = useState<string>('first');
@@ -23,33 +22,15 @@ export default function CreatePostPage() {
   const [searchInput, setSearchInput] = useState<string>('');
   //searchInput 으로 인한 centerList 중 선택 된 것이 있는지 여부
   const [selected, setSelected] = useState(false);
-  const { mutate, isSuccess, error } = useCreatePost(postData);
-  const {
-    mutate: getPostContentsList,
-    isSuccess: getPostContentsListSuccess,
-    isLoading: getPostContentsListLoading,
-    isError: getPostContentsListError,
-    data: postContentsList,
-  } = useGetPostContentsList();
-  const router = useRouter();
+  const { isLoading } = useCreatePost();
+  const { mutate: getPostContentsList, isLoading: getPostContentsListLoading } =
+    useGetPostContentsList();
 
   useEffect(() => {
-    console.log(postData);
     return () => {
       initPost();
     };
   }, [initPost]);
-
-  /**
-   * 사진 추가 핸들링 함수
-   * @param contentsList
-   */
-  const handleContentsListInput = useCallback(
-    (contentsList: { url: string }[]) => {
-      setPostData({ ...postData, contentsList });
-    },
-    [setPostData, postData]
-  );
 
   /**
    * 내용 입력 핸들링 함수
@@ -84,44 +65,15 @@ export default function CreatePostPage() {
     [setPostData, postData]
   );
 
-  const handleGoToHome = useCallback(() => {
-    router.push('/');
-  }, [router]);
-
   /**
    * 포스트 입력 완료 핸들링 함수
    */
   const handlePostDataSubmit = useCallback(() => {
     const urlList = postImageList.map(({ file }) => file);
     getPostContentsList(urlList);
-    if (getPostContentsListSuccess) {
-      console.log('success');
-      handleContentsListInput(postContentsList);
-      mutate();
-      if (isSuccess) {
-        handleGoToHome();
-        alert('입력 완료 되었습니다.');
-      } else {
-        alert(error);
-      }
-    }
-    if (getPostContentsListError) {
-      alert('이미지 업로드 중 문제가 발생하였습니다.');
-    }
-  }, [
-    mutate,
-    isSuccess,
-    error,
-    getPostContentsList,
-    handleContentsListInput,
-    getPostContentsListError,
-    postContentsList,
-    getPostContentsListSuccess,
-    postImageList,
-    handleGoToHome,
-  ]);
+  }, [postImageList, getPostContentsList]);
 
-  if (getPostContentsListLoading) {
+  if (getPostContentsListLoading && isLoading) {
     return (
       <section className=" h-screen flex justify-center items-center">
         <Loading />

--- a/packages/climbingweb/pages/feed/create/index.tsx
+++ b/packages/climbingweb/pages/feed/create/index.tsx
@@ -1,48 +1,55 @@
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
 import TextArea from 'climbingweb/src/components/common/TextArea/TextArea';
 import { UploadImageList } from 'climbingweb/src/components/CreateFeed/UploadImageList/';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { BackButton } from 'climbingweb/src/components/common/AppBar/IconButton';
 import HoldListModal from 'climbingweb/src/components/CreateFeed/SelectHoldList/HoldListModal';
 import PageSubTitle from 'climbingweb/src/components/common/PageSubTitle/PageSubTitle';
 import { NextButton } from 'climbingweb/src/components/common/AppBar/NextButton';
 import { CenterSearchInput } from 'climbingweb/src/components/CreateFeed/CenterSearchInput';
+import { ClimbingHistoryRequest } from 'climbingweb/types/request/post';
 import {
-  ClimbingHistoryRequest,
-  PostCreateRequest,
-} from 'climbingweb/types/request/post';
-import { useCreatePost } from 'climbingweb/src/hooks/queries/post/queryKey';
+  useCreatePost,
+  useGetPostContentsList,
+} from 'climbingweb/src/hooks/queries/post/queryKey';
+import { useCreatePostForm } from 'climbingweb/src/hooks/useCreatePostForm';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
+import { useRouter } from 'next/router';
 
 export default function CreatePostPage() {
   const [page, setPage] = useState<string>('first');
-  const [postData, setPostData] = useState<PostCreateRequest>({
-    centerId: '',
-    climbingHistories: [
-      {
-        climbingCount: 0,
-        holdId: '',
-      },
-    ],
-    content: '',
-    contentsList: [
-      {
-        url: '',
-      },
-    ],
-  });
+  const { postData, setPostData, postImageList, initPost } =
+    useCreatePostForm();
   const [searchInput, setSearchInput] = useState<string>('');
   //searchInput 으로 인한 centerList 중 선택 된 것이 있는지 여부
   const [selected, setSelected] = useState(false);
-
   const { mutate, isSuccess, error } = useCreatePost(postData);
+  const {
+    mutate: getPostContentsList,
+    isSuccess: getPostContentsListSuccess,
+    isLoading: getPostContentsListLoading,
+    isError: getPostContentsListError,
+    data: postContentsList,
+  } = useGetPostContentsList();
+  const router = useRouter();
+
+  useEffect(() => {
+    console.log(postData);
+    return () => {
+      initPost();
+    };
+  }, [initPost]);
 
   /**
    * 사진 추가 핸들링 함수
    * @param contentsList
    */
-  // const handleContentsListInput = (contentsList: { url: string }[]) => {
-  //   setPostData({ ...postData, contentsList });
-  // };
+  const handleContentsListInput = useCallback(
+    (contentsList: { url: string }[]) => {
+      setPostData({ ...postData, contentsList });
+    },
+    [setPostData, postData]
+  );
 
   /**
    * 내용 입력 핸들링 함수
@@ -52,7 +59,7 @@ export default function CreatePostPage() {
     (content: string) => {
       setPostData({ ...postData, content });
     },
-    [postData]
+    [setPostData, postData]
   );
 
   /**
@@ -63,7 +70,7 @@ export default function CreatePostPage() {
     (centerId: string) => {
       setPostData({ ...postData, centerId });
     },
-    [postData]
+    [setPostData, postData]
   );
 
   /**
@@ -74,20 +81,53 @@ export default function CreatePostPage() {
     (climbingHistories: ClimbingHistoryRequest[]) => {
       setPostData({ ...postData, climbingHistories });
     },
-    [postData]
+    [setPostData, postData]
   );
+
+  const handleGoToHome = useCallback(() => {
+    router.push('/');
+  }, [router]);
 
   /**
    * 포스트 입력 완료 핸들링 함수
    */
   const handlePostDataSubmit = useCallback(() => {
-    mutate();
-    if (isSuccess) {
-      alert('입력 완료 되었습니다.');
-    } else {
-      alert(error);
+    const urlList = postImageList.map(({ file }) => file);
+    getPostContentsList(urlList);
+    if (getPostContentsListSuccess) {
+      console.log('success');
+      handleContentsListInput(postContentsList);
+      mutate();
+      if (isSuccess) {
+        handleGoToHome();
+        alert('입력 완료 되었습니다.');
+      } else {
+        alert(error);
+      }
     }
-  }, [mutate, isSuccess, error]);
+    if (getPostContentsListError) {
+      alert('이미지 업로드 중 문제가 발생하였습니다.');
+    }
+  }, [
+    mutate,
+    isSuccess,
+    error,
+    getPostContentsList,
+    handleContentsListInput,
+    getPostContentsListError,
+    postContentsList,
+    getPostContentsListSuccess,
+    postImageList,
+    handleGoToHome,
+  ]);
+
+  if (getPostContentsListLoading) {
+    return (
+      <section className=" h-screen flex justify-center items-center">
+        <Loading />
+      </section>
+    );
+  }
 
   return (
     <div className="mb-footer overflow-auto scrollbar-hide">
@@ -98,7 +138,7 @@ export default function CreatePostPage() {
           <NextButton
             pageState={page}
             setPageState={setPage}
-            onSubmit={handlePostDataSubmit}
+            onSubmit={page === 'second' ? handlePostDataSubmit : null}
           />
         }
       />

--- a/packages/climbingweb/src/components/CreateFeed/UploadImageList/UploadImage.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/UploadImageList/UploadImage.tsx
@@ -1,16 +1,16 @@
 import Image from 'next/image';
 import DelButton from 'climbingweb/src/assets/icon/createFeed/ic_24_del_gray800.svg';
+import { useCreatePostForm } from 'climbingweb/src/hooks/useCreatePostForm';
 
 interface ImageProps {
   src: string;
-  media: string[];
-  setMedia: ({}: any) => void;
+  id: number;
 }
 
-export function UploadImage({ src, media, setMedia }: ImageProps) {
+export function UploadImage({ id, src }: ImageProps) {
+  const { deleteImageList } = useCreatePostForm();
   const handleDeleteMedia = () => {
-    const deletedMedia = media.filter((m) => m !== src);
-    setMedia(deletedMedia);
+    deleteImageList(id);
   };
 
   return (

--- a/packages/climbingweb/src/components/CreateFeed/UploadImageList/UploadImageButton.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/UploadImageList/UploadImageButton.tsx
@@ -1,37 +1,14 @@
 import UploadIcon from 'climbingweb/src/assets/icon/createFeed/ic_24_photo_gray800.svg';
+import { useCreatePostForm } from 'climbingweb/src/hooks/useCreatePostForm';
+const MAX_COUNT = 10;
 
-interface ButtonProps {
-  onClick?: any;
-  count?: string;
-  media?: any;
-  setMedia?: any;
-}
-
-export function UploadImageButton({ media, setMedia }: ButtonProps) {
-  const count = media.length;
-  const maxCount = 10;
+export function UploadImageButton() {
+  const { postImageList, selectImageList } = useCreatePostForm();
+  const count = postImageList.length;
 
   const handleUploadFile = (e: any) => {
-    if (count < maxCount) {
-      const files: File[] = Array.from(e.target.files);
-      console.log(files);
-      files.map((file) => {
-        let reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onload = () => {
-          const base64 = reader.result;
-          console.log('base64: ', base64);
-          if (base64) {
-            setMedia((originMedia: string[]) => [
-              ...originMedia,
-              base64.toString(),
-            ]);
-          }
-        };
-      });
-    } else {
-      alert('초과했습니다.');
-    }
+    const files: File[] = Array.from(e.target.files);
+    selectImageList(files);
   };
 
   return (
@@ -52,7 +29,7 @@ export function UploadImageButton({ media, setMedia }: ButtonProps) {
         <UploadIcon alt="upload" />
         <div>
           <span className="text-[#5953FF]">{count ? count : 0}</span>
-          <span> / {maxCount}</span>
+          <span> / {MAX_COUNT}</span>
         </div>
       </div>
     </label>

--- a/packages/climbingweb/src/components/CreateFeed/UploadImageList/index.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/UploadImageList/index.tsx
@@ -1,14 +1,15 @@
-import { useState } from 'react';
+import { useCreatePostForm } from 'climbingweb/src/hooks/useCreatePostForm';
 import { UploadImage } from './UploadImage';
 import { UploadImageButton } from './UploadImageButton';
 
 export function UploadImageList() {
-
-    const [mediaBase64, setMediaBase64] = useState<string[]>([]);
-    return (
-        <div className='w-full flex flex-row gap-2 overflow-x-auto scrollbar-hide'>
-            <UploadImageButton media={mediaBase64} setMedia={setMediaBase64} />
-            {mediaBase64?.map(image => <UploadImage media={mediaBase64} setMedia={setMediaBase64} key={image} src={image} />)}
-        </div>
-    );
+  const { postImageList } = useCreatePostForm();
+  return (
+    <div className="w-full flex flex-row gap-2 overflow-x-auto scrollbar-hide">
+      <UploadImageButton />
+      {postImageList?.map(({ thumbNail }, idx) => (
+        <UploadImage key={`key${idx}`} src={thumbNail} id={idx} />
+      ))}
+    </div>
+  );
 }

--- a/packages/climbingweb/src/hooks/queries/post/queries.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queries.ts
@@ -2,6 +2,7 @@ import {
   ChildCommentResponse,
   CommentResponse,
 } from './../../../../types/response/post/index.d';
+import { PostContents } from './../../../../types/response/post/index.d';
 import axios from 'axios';
 import { Pagination } from 'climbingweb/types/common';
 import {
@@ -227,4 +228,22 @@ export const deleteComment = async (commentId: string) => {
   } catch (error: any) {
     throw error.response.data;
   }
+};
+export const getPostContentsList = async (fileList: File[]) => {
+  let postContentsList: PostContents[] = [];
+  fileList.forEach(async (file) => {
+    const formData = new FormData();
+    formData.append('image', file);
+    try {
+      const { data } = await axios.post<string>('/posts/contents', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      postContentsList.push({ url: data });
+    } catch (error: any) {
+      throw error.response.data;
+    }
+  });
+  return postContentsList;
 };

--- a/packages/climbingweb/src/hooks/queries/post/queries.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queries.ts
@@ -231,10 +231,10 @@ export const deleteComment = async (commentId: string) => {
 export const getPostContentsList = async (fileList: File[]) => {
   const data = await axios
     .all(
-      fileList.map(async (file) => {
+      fileList.map((file) => {
         const formData = new FormData();
         formData.append('image', file);
-        await axios.post<string>('/posts/contents', formData, {
+        return axios.post<string>('/posts/contents', formData, {
           headers: {
             'Content-Type': 'multipart/form-data',
           },
@@ -243,11 +243,11 @@ export const getPostContentsList = async (fileList: File[]) => {
     )
     .then(
       axios.spread((...responses: any[]) => {
-        return responses.map((res) => res.data);
+        return responses.map((res) => ({ url: res.data }));
       })
     )
     .catch((error: any) => {
-      throw error.response.data;
+      throw error.response;
     });
   return data;
 };

--- a/packages/climbingweb/src/hooks/queries/post/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queryKey.ts
@@ -21,6 +21,8 @@ import {
   deleteLike,
   findAllChildrenComment,
   findAllParentComment,
+  findAllParentCommentAndThreeChildComment,
+  getPostContentsList,
   getPost,
   getPosts,
   updateComment,
@@ -297,4 +299,6 @@ export const useCreateReport = (postId: string) => {
   return useMutation((reportData: PostReportRequest) =>
     createReport(postId, reportData)
   );
+export const useGetPostContentsList = () => {
+  return useMutation((fileList: File[]) => getPostContentsList(fileList));
 };

--- a/packages/climbingweb/src/hooks/useCreatePostForm.ts
+++ b/packages/climbingweb/src/hooks/useCreatePostForm.ts
@@ -1,0 +1,76 @@
+import { RootState } from '../store/slices/index';
+import { useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  deleteReduxPostImageList,
+  PostImage,
+  setReduxPostData,
+  addReduxPostImage,
+  initReduxPost,
+} from '../store/slices/createFeed';
+import { bindActionCreators } from 'redux';
+
+const MAX_COUNT = 10;
+
+export const useCreatePostForm = () => {
+  const { postData, postImageList } = useSelector(
+    (state: RootState) => state.createFeed
+  );
+
+  const dispatch = useDispatch();
+  const boundActionCreators = useMemo(
+    () =>
+      bindActionCreators(
+        {
+          setReduxPostData,
+          addReduxPostImage,
+          deleteReduxPostImageList,
+          initReduxPost,
+        },
+        dispatch
+      ),
+    [dispatch]
+  );
+
+  const {
+    setReduxPostData: setPostData,
+    addReduxPostImage: addPostImage,
+    deleteReduxPostImageList: deletePostImageList,
+    initReduxPost: initPost,
+  } = boundActionCreators;
+
+  const selectImageList = (files: File[]) => {
+    // 최대 개수 초과 시 입력 방지
+    if (postImageList.length + files.length > MAX_COUNT) {
+      alert('최대 개수를 초과하였습니다.');
+      return;
+    }
+    files.forEach((file) => {
+      let reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        const base64 = reader.result?.toString();
+        if (base64) {
+          const image: PostImage = {
+            file,
+            thumbNail: base64,
+          };
+          addPostImage(image);
+        }
+      };
+    });
+  };
+
+  const deleteImageList = (id: number) => {
+    deletePostImageList(id);
+  };
+
+  return {
+    postData,
+    setPostData,
+    postImageList,
+    selectImageList,
+    deleteImageList,
+    initPost,
+  };
+};

--- a/packages/climbingweb/src/store/slices/createFeed.ts
+++ b/packages/climbingweb/src/store/slices/createFeed.ts
@@ -1,0 +1,60 @@
+import { PostCreateRequest } from './../../../types/request/post/index.d';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface PostImage {
+  file: File;
+  thumbNail: string;
+}
+
+const defaultPostImageList: PostImage[] = [];
+
+const defaultPostData: PostCreateRequest = {
+  centerId: '',
+  climbingHistories: [
+    {
+      climbingCount: 0,
+      holdId: '',
+    },
+  ],
+  content: '',
+  contentsList: [
+    {
+      url: '',
+    },
+  ],
+};
+
+const initialState = {
+  postImageList: defaultPostImageList,
+  postData: defaultPostData,
+};
+
+const createPostSlice = createSlice({
+  name: 'createFeed',
+  initialState,
+  reducers: {
+    setReduxPostData(state, action: PayloadAction<PostCreateRequest>) {
+      state.postData = action.payload;
+    },
+    addReduxPostImage(state, action: PayloadAction<PostImage>) {
+      state.postImageList.push(action.payload);
+    },
+    deleteReduxPostImageList(state, action: PayloadAction<number>) {
+      state.postImageList = state.postImageList.filter(
+        ({}, idx) => action.payload !== idx
+      );
+    },
+    initReduxPost(state) {
+      state.postData = defaultPostData;
+      state.postImageList = defaultPostImageList;
+    },
+  },
+});
+
+export default createPostSlice.reducer;
+export const {
+  setReduxPostData,
+  addReduxPostImage,
+  deleteReduxPostImageList,
+  initReduxPost,
+} = createPostSlice.actions;

--- a/packages/climbingweb/src/store/slices/index.ts
+++ b/packages/climbingweb/src/store/slices/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
 import ui from './uiSlice';
 import auth from './auth';
+import createFeed from './createFeed';
 const rootReducer = combineReducers({
   ui,
   auth,
+  createFeed,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
## Related issue
Fixes #issue number

##Image
![포스트생성](https://user-images.githubusercontent.com/33804074/207230867-fe92a8fd-4526-4a91-98de-a075941bb746.gif)


## Description
- post 관련 데이터들 리덕스로 옮김
- 이미지 s3에 업로드 구현
- 포스트 생성 적용

## Changes detail
- post 관련 데이터 => 리덕스
  - 데이터 관리를  redux store의 createSlice 에서 주관하기 위해
- 이미지 s3 업로드 로직 구현
  -  getContentsList(),  useGetContentsList()  사용
  -  설정한 이미지만큼 한번에 여러 요청
  -  onSuccess 일 때: 이미지 저장 성공 시 포스트 생성 동기적으로 요청 
  - onError일 때:  에러 alert
- 포스트 생성 적용
  - useGetContnetsList() 수행 후 성공 시 동기적 수행
  - onsuccess : 포스트 생성 성공 alert 후 home 화면 이동
  - onError :  alert 후 **페이지 refresh**


### Checklist
- [ ] Test case
- [x] End of work
