### PR TITLE
fix: 1차 자체 QA

### DIFF
--- a/packages/climbingweb/pages/feed/[fid].tsx
+++ b/packages/climbingweb/pages/feed/[fid].tsx
@@ -1,6 +1,6 @@
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
 import {
-  AppLogo,
+  BackButton,
   ModifiedButton,
 } from 'climbingweb/src/components/common/AppBar/IconButton';
 import { ListSheet } from 'climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet';
@@ -30,7 +30,7 @@ export default function FeedPage({}) {
   if (postData)
     return (
       <section>
-        <AppBar leftNode={<AppLogo />} rightNode={<ModifiedButton />} />
+        <AppBar leftNode={<BackButton />} rightNode={<ModifiedButton />} />
         <HomeFeed postData={postData} />
         <BottomSheet open={openBTSheet} onDismiss={() => setOpenBTSheet(false)}>
           <ListSheet

--- a/packages/climbingweb/pages/feed/[fid].tsx
+++ b/packages/climbingweb/pages/feed/[fid].tsx
@@ -1,8 +1,5 @@
 import { AppBar } from 'climbingweb/src/components/common/AppBar';
-import {
-  BackButton,
-  ModifiedButton,
-} from 'climbingweb/src/components/common/AppBar/IconButton';
+import { BackButton } from 'climbingweb/src/components/common/AppBar/IconButton';
 import { ListSheet } from 'climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet';
 import Loading from 'climbingweb/src/components/common/Loading/Loading';
 import HomeFeed from 'climbingweb/src/components/HomeFeed/HomeFeed';
@@ -25,12 +22,15 @@ export default function FeedPage({}) {
     error: postError,
   } = useGetPost(feedId);
 
+  //뒤로가기 버튼 클릭 핸들러
+  const handleBackButtonClick = () => window.history.back();
+
   if (isPostError) return <div>{postError}</div>;
 
   if (postData)
     return (
       <section>
-        <AppBar leftNode={<BackButton />} rightNode={<ModifiedButton />} />
+        <AppBar leftNode={<BackButton onClick={handleBackButtonClick} />} />
         <HomeFeed postData={postData} />
         <BottomSheet open={openBTSheet} onDismiss={() => setOpenBTSheet(false)}>
           <ListSheet

--- a/packages/climbingweb/src/components/CreateFeed/SelectHoldList/HoldListModal.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/SelectHoldList/HoldListModal.tsx
@@ -5,7 +5,6 @@ import { ClimbingHistoryRequest } from 'climbingweb/types/request/post';
 import React, { useCallback, useEffect, useState } from 'react';
 import EmptyContent from '../../common/EmptyContent/EmptyContent';
 import ErrorContent from '../../common/Error/ErrorContent';
-import Loading from '../../common/Loading/Loading';
 import HoldImage from './HoldImage';
 import HoldImageButton from './HoldImageButton';
 
@@ -98,7 +97,9 @@ const HoldListModal = ({
       0
     );
     setTotalHoldCount(totalCount);
-    setData(holdToClimbingHistories(selectedHold));
+    setData(
+      holdToClimbingHistories(selectedHold.filter((hold) => hold.count > 0))
+    );
     setSelectedHold(selectedHold);
   }, [selectedHold, holdToClimbingHistories, setData]);
 
@@ -237,7 +238,7 @@ const HoldListModal = ({
       </>
     );
 
-  return <Loading />;
+  return <HoldImageButton count={totalHoldCount} maxCount={maxCount} />;
 };
 
 export default HoldListModal;

--- a/packages/climbingweb/src/components/HomeFeed/FeedSectorInfo/FeedSectorInfo.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/FeedSectorInfo/FeedSectorInfo.tsx
@@ -9,21 +9,10 @@ const FeedHoldIcon = ({
   index: number;
   value: ClimbingHistoryResponse;
 }) => (
-  <>
-    <div
-      className="rounded-lg mx-1.5 min-w-10 relative"
-      key={`feedHoldIcon_${value.holdId}`}
-    >
-      <Image
-        className="rounded-lg"
-        layout="fill"
-        objectFit="scale-down"
-        src={value.holdImage}
-        alt={`${index}`}
-      />
-    </div>
-    <div className="text-purple-500">{value.climbingCount}</div>
-  </>
+  <div className="relative flex items-center mx-1.5 min-w-10 text-purple-500">
+    <Image src={value.holdImage} alt={`${index}`} height={24} width={24} />
+    {value.climbingCount}
+  </div>
 );
 
 const FeedSectorInfo = ({
@@ -32,9 +21,11 @@ const FeedSectorInfo = ({
   holdList: ClimbingHistoryResponse[];
 }) => {
   return (
-    <div className={'flex flex-col w-full border-b border-gray-300'}>
+    <div
+      className={'flex border-b border-gray-300 overflow-auto scrollbar-hide'}
+    >
       <div className={'flex mx-5 my-4'}>
-        <div className={'mr-5 font-medium text-gray-600'}>홀드</div>
+        <div className={'mr-5 font-medium text-gray-600 min-w-fit'}>홀드</div>
         {holdList.map((value, index) => (
           <FeedHoldIcon
             key={`feedHoldIcon${value.holdId}${index}`}

--- a/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
+++ b/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
@@ -6,6 +6,8 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
   //피드에서 현재 보여질 이미지 index
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
+  const imageWidth = window.innerWidth;
+
   const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
     const touchX = event.changedTouches[0].pageX;
     if (touchX > 200) {
@@ -30,13 +32,13 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
 
   return (
     <div
-      className={'bg-black relative w-full overflow-hidden'}
+      className={`bg-black relative w-full h-[${imageWidth}px] overflow-hidden`}
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
     >
       <div
-        className={`h-[360px] -ml-[${
-          selectedImageIndex * 360
+        className={`h-[${imageWidth}px] w-[3000px] relative -ml-[${
+          selectedImageIndex * imageWidth
         }px] transition-all 0.5s`}
       >
         {imageList.map((value, index) =>
@@ -44,12 +46,15 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
             <Image
               key={`sectorInfo${index}`}
               src={value}
-              width={'360px'}
-              height={'360px'}
+              width={`${imageWidth}px`}
+              height={`${imageWidth}px`}
               alt={'sliderImage'}
             />
           ) : (
-            <div key={`sectorInfo${index}`} className={'w-[360px] h-[360px]'}>
+            <div
+              key={`sectorInfo${index}`}
+              className={`w-[${imageWidth}px] h-[${imageWidth}px]`}
+            >
               <div
                 className={
                   'border-t-transparent animate-spin inline-block w-8 h-8 border-4 rounded-full'

--- a/packages/climbingweb/src/components/User/MiniHold.tsx
+++ b/packages/climbingweb/src/components/User/MiniHold.tsx
@@ -8,8 +8,8 @@ interface MiniHoldProps {
 
 const MiniHold = ({ hold }: MiniHoldProps) => {
   return (
-    <div className="flex justify-center text-xs">
-      <Image height={10} width={10} src={hold.holdImage} alt={hold.holdId} />
+    <div className="relative flex items-center text-xs min-w-fi ">
+      <Image height={12} width={12} src={hold.holdImage} alt={hold.holdId} />
       {hold.climbingCount}
     </div>
   );

--- a/packages/climbingweb/src/components/User/UserFeed.tsx
+++ b/packages/climbingweb/src/components/User/UserFeed.tsx
@@ -25,21 +25,25 @@ const UserFeed = ({
 
   return (
     <div
-      className="flex flex-col my-1 mr-2 pb-3 rounded-xl shadow-lg max-w-[160px] h-[200px]"
+      className="flex flex-col my-1 mr-2 pb-[5px] rounded-lg shadow-lg max-w-[160px] h-[210px]"
       onClick={handleFeedClick}
     >
-      <Image
-        src={image}
-        alt={'UserFeedImage'}
-        height={160}
-        width={160}
-        sizes={'(max-width: 160px)'}
-      />
-      <div className="ml-3 my-1 text-gray-500 text-sm">{centerName}</div>
-      <div className="grid grid-cols-4 h-[40px] overflow-auto scrollbar-hide">
-        {climbingHistories.map((value, index) => (
-          <MiniHold key={`miniHold_${index}`} hold={value} />
-        ))}
+      <div className="relative flex">
+        <Image
+          className="rounded-t-lg"
+          src={image}
+          alt={'UserFeedImage'}
+          height={160}
+          width={160}
+        />
+      </div>
+      <div className="ml-3 my-1 text-gray-500 text-xs">
+        {centerName}
+        <div className="flex overflow-auto scrollbar-hide justify-between">
+          {climbingHistories.map((value, index) => (
+            <MiniHold key={`miniHold_${index}`} hold={value} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/packages/climbingweb/src/components/User/UserHead.tsx
+++ b/packages/climbingweb/src/components/User/UserHead.tsx
@@ -34,6 +34,10 @@ export const UserHead = ({
 
   const router = useRouter();
 
+  const handleProfileIconClick = () => {
+    if (instagramUrl) router.push(instagramUrl);
+  };
+
   return (
     <div className="flex flex-col gap-4 px-6 py-4 shadow-sm my-4 rounded-lg">
       <div className="flex flex-row items-center justify-between">
@@ -41,9 +45,8 @@ export const UserHead = ({
           <ProfileImage
             src={imagePath}
             icon={instagramUrl ? 'insta' : 'default'}
-            onClickIcon={() => {
-              if (instagramUrl) router.push(instagramUrl);
-            }}
+            onClickIcon={handleProfileIconClick}
+            size={60}
           />
         </div>
         <div className="flex flex-col gap-1.5 w-52 ml-7">

--- a/packages/climbingweb/src/components/User/UserRecord.tsx
+++ b/packages/climbingweb/src/components/User/UserRecord.tsx
@@ -10,24 +10,25 @@ const UserRecord = ({
   climbingHistories,
 }: UserRecordProps) => {
   return (
-    <div className="rounded-xl p-1 shadow-sm mt-2 mr-3 shadow-gray-300 h-36 min-w-[90px]">
-      <Image
-        className="rounded-full"
-        src={centerImage}
-        alt={centerName}
-        height={80}
-        width={80}
-        sizes={'(max-width: 80px)'}
-      />
-      <div className="text-gray-400 ml-1 text-xs line-clamp-1">
-        {centerName}
+    <span className="flex flex-col rounded-lg shadow-sm mr-2 shadow-gray-300 h-[155px] min-w-[90px] pb-[5px]">
+      <div className="aspect-square flex items-center justify-center mx-[5px] p-[5px]">
+        <Image
+          className="relative rounded-full"
+          src={centerImage}
+          alt={centerName}
+          height={80}
+          width={80}
+        />
       </div>
-      <div className="grid grid-cols-3 overflow-auto scrollbar-hide">
-        {climbingHistories.map((value, index) => (
-          <MiniHold key={`miniHold_${index}`} hold={value} />
-        ))}
+      <div className="pl-[5px] pr-2">
+        <div className="text-gray-400 text-xs line-clamp-1">{centerName}</div>
+        <div className="grid grid-cols-3  overflow-auto scrollbar-hide">
+          {climbingHistories.map((value, index) => (
+            <MiniHold key={`miniHold_${index}`} hold={value} />
+          ))}
+        </div>
       </div>
-    </div>
+    </span>
   );
 };
 

--- a/packages/climbingweb/src/components/User/UserRecordList.tsx
+++ b/packages/climbingweb/src/components/User/UserRecordList.tsx
@@ -7,7 +7,7 @@ interface UserRecordListProps {
 }
 
 const UserRecordList = ({ userDetailData }: UserRecordListProps) => (
-  <div>
+  <>
     {userDetailData.centerClimbingHistories.map((value, index) => (
       <UserRecord
         key={`UserRecord_${index}`}
@@ -15,7 +15,7 @@ const UserRecordList = ({ userDetailData }: UserRecordListProps) => (
         climbingHistories={value.climbingHistories}
       />
     ))}
-  </div>
+  </>
 );
 
 export default UserRecordList;

--- a/packages/climbingweb/src/components/common/PageSubTitle/PageSubTitle.tsx
+++ b/packages/climbingweb/src/components/common/PageSubTitle/PageSubTitle.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 interface PageSubTitleProps {
   title: string;
@@ -8,4 +8,4 @@ const PageSubTitle = ({ title }: PageSubTitleProps) => {
   return <h2 className="text-lg font-extrabold leading-6">{title}</h2>;
 };
 
-export default PageSubTitle;
+export default memo(PageSubTitle);

--- a/packages/climbingweb/src/components/common/profileImage/ProfileImage.tsx
+++ b/packages/climbingweb/src/components/common/profileImage/ProfileImage.tsx
@@ -7,22 +7,26 @@ interface ProfileProps {
   src?: string;
   icon?: 'default' | 'insta';
   onClickIcon?: () => void;
+  size?: number;
 }
 
-export const ProfileImage = ({ src, icon, onClickIcon }: ProfileProps) => {
+export const ProfileImage = ({
+  src,
+  icon,
+  onClickIcon,
+  size,
+}: ProfileProps) => {
   return (
     <div className="w-16 relative">
-      <div className="w-15 h-15 rounded-xl relative">
+      <div className="w-15 h-15 rounded-xl relative flex items-center justify-center">
         {src ? (
-          <div className="w-16 h-16 flex items-center justify-center">
-            <Image
-              className="relative rounded-full"
-              src={src}
-              alt="profile"
-              height={40}
-              width={40}
-            />
-          </div>
+          <Image
+            className="relative rounded-full"
+            src={src}
+            alt="profile"
+            height={size ? size : 40}
+            width={size ? size : 40}
+          />
         ) : (
           <ProfileSkeleton />
         )}

--- a/packages/climbingweb/src/hooks/queries/center/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/center/queryKey.ts
@@ -134,10 +134,10 @@ export const useFindHoldInfoByCenter = (centerId: string) => {
   return useQuery({
     ...centerQueries.detail(centerId)._ctx.findHoldInfoByCenter(),
     enabled: Boolean(centerId),
-    select: (response) =>
-      response.map((val) => {
-        return { ...val, count: 0 };
-      }),
+    // select: (response) =>
+    //   response.map((val) => {
+    //     return { ...val, count: 0 };
+    //   }),
   });
 };
 

--- a/packages/climbingweb/src/interface/CenterName.ts
+++ b/packages/climbingweb/src/interface/CenterName.ts
@@ -1,4 +1,0 @@
-export default interface CenterName {
-  id: string;
-  name: string;
-}


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue is fixed.

## Changes detail

- 피드 관련 마크업 수정
  1. AppBar 클라온 로고에서 뒤로가기로 수정
  2. UserHead 인스타 프로필 아이콘  클릭 핸들러 추가 (작동은 나중에)
  3. ProfileImage size 지정 가능하도록 변경 및 기본 사이즈 지정(40px)

  나머지 css 수정
  1. HomeFeed 홀드 정보 잘 뜨게 수정
  2. MiniHold 컴포넌트 css 수정
  3. UserFeed css 수정
  4. UserRecord css 수정 및 마크업 수정
 
- hold 갯수가 0 개인 경우 필터링 하는 로직 추가
  post 생성 시 hold 개수가 0 개 인 경우는 아예 해당 hold 를 추가하지 않아야 하는데, 0개로 추가하는 현상이 있었음 이를 해결

- post create 페이지 암장 검색 후 hold modal 뜨는 것 자잘한 오류 수정 및 로직 정리
  1. 페이지 암장 검색 input 컴포넌트 css 동작이 이상한 것 수정( 검색 결과가 없는데, 아래 border 가 round css 미적용 되어 부자연 스러워 보였음)
  2. CenterSearchInput 컴포넌트 및 Modal 컴포넌트 server state 를 page 로 옮김
     이전엔 해당 컴포넌트 들이 server state 를 가지고 있어서 일관성이 없었으나, page 로 옮기고 해당 컴포넌트들은 view 만 보여주도록 변경
  3. findHoldInfoByCenter 관련 쿼리 return 값 후처리를 modal 컴포넌트에서 하도록 변경
  4. CenterName 이라는 쓸모없는 파일 삭제

- image slider 미작동 오류 해결

### Checklist

- [ ] Test case
- [ ] End of work
