### PR TITLE
fix: #169, #170, #171 해결

### DIFF
--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -59,9 +59,11 @@ const Home: NextPage = () => {
     return (
       <div className="mb-footer overflow-auto scrollbar-hide">
         <AppBar
+          className="fixed top-0 z-10 bg-white w-full"
           leftNode={<AppLogo />}
           rightNode={<ModifiedButton onClick={onClickCreateFeed} />}
         />
+        <div className="h-16"></div>
         {laonPostsData.pages.map((page) => {
           return page.results.map((result, index) => (
             <HomeFeed key={`laonPostsDataFeed_${index}`} postData={result} />

--- a/packages/climbingweb/src/components/HomeFeed/FeedContent/FeedContent.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/FeedContent/FeedContent.tsx
@@ -54,12 +54,14 @@ const FeedContent = ({
       ) : (
         <p className="py-2 font-medium">{content}</p>
       )}
-      {replyCount ? (
+      {
         <p
           onTouchEnd={onClickMoreComment}
           className="font-medium text-gray-400"
-        >{`댓글 ${replyCount}개 더 보기`}</p>
-      ) : null}
+        >
+          {replyCount === 0 ? '댓글 달기' : `댓글 ${replyCount}개 더 보기`}
+        </p>
+      }
     </section>
   );
 };

--- a/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
+++ b/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
@@ -1,7 +1,7 @@
 import { useCreateLaon } from 'climbingweb/src/hooks/queries/laon/queryKey';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { ProfileImage } from '../../common/profileImage/ProfileImage';
 
 interface UserProps {
   imagePath: string;
@@ -30,13 +30,7 @@ const UserResult = ({ imagePath, isLaon, nickname }: UserProps) => {
   return (
     <div className="relative flex flex-col mx-2 items-center text-center w-[75px] h-[110px] rounded-[4px] border-gray-400 border-2 text-[8px] p-1">
       <div onClick={handleUserResultClick}>
-        <Image
-          className="rounded-full"
-          src={imagePath}
-          alt={'raonImage'}
-          width={'45px'}
-          height={'45px'}
-        />
+        <ProfileImage src={imagePath} size={45} />
         {nickname}
       </div>
       <button

--- a/packages/climbingweb/src/components/common/AppBar/index.tsx
+++ b/packages/climbingweb/src/components/common/AppBar/index.tsx
@@ -1,16 +1,16 @@
 interface Props {
-    title?: string;
-    leftNode?: JSX.Element
-    rightNode?: JSX.Element;
+  className?: string;
+  title?: string;
+  leftNode?: JSX.Element;
+  rightNode?: JSX.Element;
 }
 
-export function AppBar({ title, leftNode, rightNode }: Props) {
-
-    return (
-        <header className='flex flex-row justify-between p-4'>
-            {leftNode}
-            <h1 className='font-bold'>{title}</h1>
-            {rightNode}
-        </header>
-    );
+export function AppBar({ className, title, leftNode, rightNode }: Props) {
+  return (
+    <header className={`flex flex-row justify-between p-4 ${className}`}>
+      {leftNode}
+      <h1 className="font-bold">{title}</h1>
+      {rightNode}
+    </header>
+  );
 }


### PR DESCRIPTION
## Related issue

resolves #171 
resolves #170 
resolves #169 

## Description

#171 검색버그
#170 피드 댓글 이슈
#169 헤더 GNB 이슈

## Changes detail

- 헤더 GNB 이슈
  css position : sticky 는 상위 요소가 overflow 속성을 가지고 있으면 적용이 되지 않아서 fixed 로 적용
- 피드 댓글 이슈
  상의 후 댓글이 0개인 경우 댓글 달기 문자열이 보이도록 추가
- 검색 버그
  next/Image 컴포넌트는 src 의 default 값의 문제가 있어 ProfileImage 컴포넌트에 관련 문제를 해결해 둔 적이 있었음
  해당 버그도 Image 컴포넌트 src 의 default 값 문제라서 ProfileImage 로 문제 해결

### Checklist

- [ ] Test case
- [ ] End of work
