### PR TITLE
[WEB] #179, #180, #181 해결

### DIFF
--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -70,11 +70,7 @@ const Home: NextPage = () => {
           ));
         })}
         {!hasNextLaonPosts ? (
-          <div className="m-4 font-medium">
-            <div className="h-[1px] my-2 bg-slate-300"></div>
-            <div>추천 게시글</div>
-            <div className="h-[1px] my-2 bg-slate-300"></div>
-          </div>
+          <div className="m-4 font-medium">추천 게시글</div>
         ) : null}
         {postsData.pages.map((page) => {
           return page.results.map((result, index) => (

--- a/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
+++ b/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
@@ -3,6 +3,10 @@ import React, { useState } from 'react';
 import { TouchEvent } from 'react';
 import Loading from '../common/Loading/Loading';
 
+const imageLoader = ({ src, width }: { src: string; width: number }) => {
+  return `${src}?w=${width}`;
+};
+
 const ImageSlider = ({ imageList }: { imageList: string[] }) => {
   //피드에서 현재 보여질 이미지 index
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -39,7 +43,9 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
               src={value}
               width={`${imageWidth}px`}
               height={`${imageWidth}px`}
+              objectFit={'contain'}
               alt={'sliderImage'}
+              loader={imageLoader}
             />
           ) : (
             <div key={value} className={'w-full aspect-square'}>

--- a/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
+++ b/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
@@ -26,7 +26,7 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
 
   return (
     <div
-      className={'relative w-full aspect-square overflow-hidden bg-black'}
+      className={'relative w-full aspect-square overflow-hidden'}
       onTouchEnd={onTouchEnd}
     >
       <div

--- a/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
+++ b/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
@@ -26,7 +26,7 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
 
   return (
     <div
-      className={'relative w-full aspect-square overflow-hidden'}
+      className={'relative w-full aspect-square overflow-hidden bg-black'}
       onTouchEnd={onTouchEnd}
     >
       <div

--- a/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
+++ b/packages/climbingweb/src/components/ImageSlider/ImageSlider.tsx
@@ -57,16 +57,18 @@ const ImageSlider = ({ imageList }: { imageList: string[] }) => {
       <div
         className={'flex w-full my-4 absolute left-0 bottom-0 justify-center'}
       >
-        <div className="flex rounded-full bg-black bg-opacity-50">
-          {imageList.map((value, index) => (
-            <div
-              key={`justDot${index}`}
-              className={`w-2 h-2 m-1 rounded-full bg-white ${
-                selectedImageIndex === index ? 'opacity-100' : 'opacity-40'
-              }`}
-            />
-          ))}
-        </div>
+        {imageList.length > 1 && (
+          <div className="flex rounded-full">
+            {imageList.map((value, index) => (
+              <div
+                key={`justDot${index}`}
+                className={`w-2 h-2 m-1 rounded-full bg-purple-500 ${
+                  selectedImageIndex === index ? 'opacity-100' : 'opacity-40'
+                }`}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/climbingweb/src/components/User/UserFeed.tsx
+++ b/packages/climbingweb/src/components/User/UserFeed.tsx
@@ -40,6 +40,7 @@ const UserFeed = ({
           alt={'UserFeedImage'}
           height={160}
           width={160}
+          objectFit={'contain'}
         />
       </div>
       <div className="ml-3 my-1 text-gray-500 text-xs scrollbar-hide">

--- a/packages/climbingweb/src/components/User/UserFeed.tsx
+++ b/packages/climbingweb/src/components/User/UserFeed.tsx
@@ -33,7 +33,7 @@ const UserFeed = ({
       className="flex flex-col my-1 mr-2 pb-[5px] rounded-lg shadow-lg max-w-[160px] h-[230px]"
       onClick={handleFeedClick}
     >
-      <div className="relative flex">
+      <div className="relative flex bg-black rounded-t-lg">
         <Image
           className="rounded-t-lg"
           src={image}

--- a/packages/climbingweb/src/components/User/UserFeed.tsx
+++ b/packages/climbingweb/src/components/User/UserFeed.tsx
@@ -33,7 +33,7 @@ const UserFeed = ({
       className="flex flex-col my-1 mr-2 pb-[5px] rounded-lg shadow-lg max-w-[160px] h-[230px]"
       onClick={handleFeedClick}
     >
-      <div className="relative flex bg-black rounded-t-lg">
+      <div className="relative flex rounded-t-lg">
         <Image
           className="rounded-t-lg"
           src={image}

--- a/packages/climbingweb/src/components/User/UserRecord.tsx
+++ b/packages/climbingweb/src/components/User/UserRecord.tsx
@@ -4,13 +4,12 @@ import React from 'react';
 import { UserRecordSkeleton } from '../common/skeleton/UserRecordSkeleton';
 import MiniHold from './MiniHold';
 
-interface UserRecordProps extends CenterClimbingHistoryResponse { }
+interface UserRecordProps extends CenterClimbingHistoryResponse {}
 
 const UserRecord = ({
   center: { centerName, centerImage },
   climbingHistories,
 }: UserRecordProps) => {
-
   if (!(centerName && centerImage)) {
     return <UserRecordSkeleton />;
   }
@@ -24,6 +23,7 @@ const UserRecord = ({
           alt={centerName}
           height={80}
           width={80}
+          objectFit={'contain'}
         />
       </div>
       <div className="pl-[5px] pr-2">

--- a/packages/climbingweb/src/components/common/LaonList/LaonItem.tsx
+++ b/packages/climbingweb/src/components/common/LaonList/LaonItem.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import Router from 'next/router';
+import { ProfileImage } from '../profileImage/ProfileImage';
 import { LaonProps } from './type';
 
 export const LaonItem = ({
@@ -22,15 +22,7 @@ export const LaonItem = ({
         className="flex flex-row items-center gap-2"
         onClick={!disabled ? handleLaonItemClick : undefined}
       >
-        <div className="h-10 w-10 relative">
-          <Image
-            className="rounded-full"
-            layout="fill"
-            objectFit="cover"
-            src={laonProfileImage}
-            alt="laonProfileImage"
-          />
-        </div>
+        <ProfileImage src={laonProfileImage} />
         <p className="text-sm font-bold">{laonNickName}</p>
       </div>
       {rightNode}


### PR DESCRIPTION
## Related issue

resolves #179
resolves #180
resolves #181

## Description

#179 추천게시글 요소 위 아래 회색 줄 삭제
#180 이미지가 이미지 컴포넌트 크기에 따라 찌그러지는 현상
#181 내 라온 페이지 이미지 깨지는 현상

## Changes detail

- #179   
![image](https://user-images.githubusercontent.com/37992140/209910950-3cffac0b-e510-49a7-9a1d-70f43782a371.png)
  기존 추천 게시글엔 회색 줄이 존재 했었음..

- #180 
  
![image](https://user-images.githubusercontent.com/37992140/209911028-750d59a7-ba56-42cd-9b7e-4036cf767c30.png)
  이미지 컴포넌트 크기에 맞춰 찌그러지는 현상 수정 (objectFi='contain' option 이용)

- #181 
  ProfileImage 를 사용하면 되는 것을 일반 Image 사용하여 생기던 현상 수정


### Checklist

- [ ] Test case
- [ ] End of work
