### PR TITLE
chore: 안드로이드 release 파일 빌드를 위한 빌드 관련 코드 변경

### DIFF
--- a/packages/climbingapp/android/app/build.gradle
+++ b/packages/climbingapp/android/app/build.gradle
@@ -99,12 +99,12 @@ apply from: "../../../../node_modules/react-native/react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.
@@ -135,16 +135,16 @@ def nativeArchitectures = project.getProperties().get("reactNativeDebugArchitect
 
 android {
     ndkVersion rootProject.ext.ndkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         resValue "string", "build_config_package", "com.climbingapp"
         applicationId "com.climbingapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1"
     }
     splits {
         abi {
@@ -155,13 +155,17 @@ android {
         }
     }
     signingConfigs {
+        Properties properties = new Properties();
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        def MYAPP_RELEASE_STORE_FILE = properties.getProperty('MYAPP_RELEASE_STORE_FILE')
+        def MYAPP_RELEASE_STORE_PASSWORD = properties.getProperty('MYAPP_RELEASE_STORE_PASSWORD')
+        def MYAPP_RELEASE_KEY_ALIAS = properties.getProperty('MYAPP_RELEASE_KEY_ALIAS')
+        def MYAPP_RELEASE_KEY_PASSWORD = properties.getProperty('MYAPP_RELEASE_KEY_PASSWORD')
         release {
-            if (project.hasProperty('MYAPP_RELEASE_STORE_FILE')) {
                 storeFile file(MYAPP_RELEASE_STORE_FILE)
                 storePassword MYAPP_RELEASE_STORE_PASSWORD
                 keyAlias MYAPP_RELEASE_KEY_ALIAS
                 keyPassword MYAPP_RELEASE_KEY_PASSWORD
-            }
         }
         debug {
             storeFile file('debug.keystore')

--- a/packages/climbingapp/android/app/src/main/AndroidManifest.xml
+++ b/packages/climbingapp/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustPan">
+        android:windowSoftInputMode="adjustPan"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/packages/climbingapp/android/build.gradle
+++ b/packages/climbingapp/android/build.gradle
@@ -4,9 +4,9 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
-        kotlinVersion = '1.4.0'
+        compileSdkVersion = 31
+        targetSdkVersion = 31
+        kotlinVersion = '1.7.0'
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.2")
+        classpath('com.android.tools.build:gradle:7.1.3')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/packages/climbingapp/android/gradle.properties
+++ b/packages/climbingapp/android/gradle.properties
@@ -1,8 +1,4 @@
 # Project-wide Gradle settings.
-MYAPP_RELEASE_STORE_FILE=claon-key.keystore
-MYAPP_RELEASE_KEY_ALIAS=claon
-MYAPP_RELEASE_STORE_PASSWORD=claon1234
-MYAPP_RELEASE_KEY_PASSWORD=claon1234
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*
 # any settings specified in this file.


### PR DESCRIPTION
## Related issue

## Description
안드로이드 릴리즈 번들 빌드를 위한 버전 및 설정 변경

## Changes detail
- 안드로이드 릴리즈를 위한 타겟 SDK 버전 30 => 31
- 코틀린 1.4.0 => 1.7.0
- gradle 버전 4.2.2 => 7.1.3
- 배포 버전코드 업
- 배포 버전 1.0.1
