### PR TITLE
fix: oauth 로그인 실패 시 회원가입 화면으로 바로 넘어가는 로직 수정

### DIFF
--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -13,6 +13,7 @@ import Config from 'react-native-config';
 import { api } from '../utils/constants';
 import axios from 'axios';
 import { AccessTokenType } from '@actbase/react-kakaosdk/lib/types';
+import { Alert } from 'react-native';
 
 interface SignInType {
   code: string | AccessTokenType;
@@ -55,21 +56,23 @@ export const useAuth = () => {
         );
         return res;
       })
-      .catch((error) => console.log(error));
+      .catch((error) => {
+        console.log(error);
+        Alert.alert(
+          '에러',
+          '서버에 문제가 있습니다. 잠시 후 다시 시도해주세요.'
+        );
+      });
 
     return signValue;
   };
 
   const kakaoLogin = async () => {
-    try {
-      await KakaoSDK.init(Config.KAKAO_APP_KEY);
-      const token = await KakaoSDK.login();
-      const code = token?.access_token;
-      if (code) {
-        return await signInWithProvider({ code, provider: 'KAKAO' });
-      }
-    } catch (err) {
-      console.log(err);
+    await KakaoSDK.init(Config.KAKAO_APP_KEY);
+    const token = await KakaoSDK.login();
+    const code = token?.access_token;
+    if (code) {
+      return signInWithProvider({ code, provider: 'KAKAO' });
     }
   };
 

--- a/packages/climbingapp/src/types/type.d.ts
+++ b/packages/climbingapp/src/types/type.d.ts
@@ -1,0 +1,5 @@
+export interface ErrorResponse {
+  errorCode: number;
+  message: string | null;
+  timeStamp: string;
+}


### PR DESCRIPTION
## Related issue
Fixes #189

## Description
로그인을 하지 않았을 때 회원가입으로 넘어가는 이슈 fix

## Changes detail
- 소셜 로그인 진행  중 취소 에러 대응 x =>  로그인 화면으로 돌아옴
- 서버 에러 발생 시 alert 노출
  -  에러 번호
  -  에러 메시지 노출
  - 네트워크 에러 따로 처리   ( 제목 : 에러,  문구: 서버에 문제가 있습니다. 잠시 후 다시 시도해주세요.)
-  sign-in api 정상 수신 시  로그인 / 회원가입 분기 처리   

### Checklist

- [ ] Test case
- [x] End of work
