### PR TITLE
fix: 앱 재실행 시 토큰 저장 확인 후 자동 로그인 적용, 로그아웃 시 토큰만료 후 로그인 화면 이동하도록 로직 수정

### DIFF
--- a/packages/climbingapp/src/component/webview/CustomWebView.tsx
+++ b/packages/climbingapp/src/component/webview/CustomWebView.tsx
@@ -1,4 +1,6 @@
+import { useNavigation } from '@react-navigation/native';
 import { useAuth } from 'climbingapp/src/hooks/useAuth';
+import { LoginScreenProp } from 'climbingapp/src/navigation/screens/auth/type';
 import { injectedScriptForWebViewBackButton } from 'climbingapp/src/utils/constants';
 import { storeData } from 'climbingapp/src/utils/storage';
 import React, { useEffect, useRef, useState } from 'react';
@@ -12,6 +14,8 @@ interface WebInfo {
 export default function CustomWebView({ url }: WebInfo) {
   const webviewRef = useRef<WebView>(null);
   const { user, logout } = useAuth();
+  const navigation = useNavigation<LoginScreenProp>();
+
   const sendTokenToWebview = () => {
     if (user) {
       const { accessToken, refreshToken } = user;
@@ -56,6 +60,7 @@ export default function CustomWebView({ url }: WebInfo) {
       }
       if (data.type === 'logout') {
         logout();
+        navigation.reset({ routes: [{ name: 'login' }] });
       }
     }
     if (state.data === 'navigationStateChange') {

--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -1,7 +1,11 @@
 import { storeData } from './../utils/storage';
 import { RootState } from './../store/slices/index';
 import KakaoSDK from '@actbase/react-kakaosdk';
-import { authorize, logout, User } from 'climbingapp/src/store/slices/auth';
+import {
+  authorizeAction,
+  logoutAction,
+  User,
+} from 'climbingapp/src/store/slices/auth';
 import { useSelector, useDispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
@@ -25,24 +29,30 @@ const useUserInfo = () => {
 
 const useAuthActions = () => {
   const dispatch = useDispatch();
-  return bindActionCreators({ authorize, logout }, dispatch);
+  return bindActionCreators({ authorizeAction, logoutAction }, dispatch);
 };
 
 export const useAuth = () => {
   const user = useUser();
   const auth = useAuthActions();
+  const { authorizeAction: authorize, logoutAction: logout } = auth;
   const userInfo = useUserInfo();
 
   const signInWithProvider = async ({ code, provider }: SignInType) => {
-    const signValue: User = await axios
+    const signValue = await axios
       .post(api + '/auth/sign-in/' + provider, {
         code,
       })
       .then((res) => res.data)
-      .then((res) => {
-        auth.authorize(res);
-        storeData('access-token', res.accessToken);
-        storeData('refresh-token', res.refreshToken);
+      .then(async (res: User) => {
+        authorize(res);
+        console.log(res);
+        await storeData('access-token', res.accessToken);
+        await storeData('refresh-token', res.refreshToken);
+        await storeData(
+          'isCompletedSignUp',
+          JSON.stringify(res.isCompletedSignUp)
+        );
         return res;
       })
       .catch((error) => console.log(error));

--- a/packages/climbingapp/src/navigation/LoginNavigator.tsx
+++ b/packages/climbingapp/src/navigation/LoginNavigator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from './screens/auth/LoginScreen';
 import RegisterScreen from './screens/auth/RegisterScreen';
@@ -11,6 +11,8 @@ import InstagramAuthWebView from '../component/webview/InstagramAuthWebview';
 import Config from 'react-native-config';
 import SignUpStepTwoScreen from './screens/auth/SignUpStepTwoScreen';
 import HomeScreen from './screens/main/HomeScreen';
+import { getData } from '../utils/storage';
+import { useAuth } from '../hooks/useAuth';
 const Stack = createNativeStackNavigator();
 
 const LoginNavigator = () => {
@@ -20,12 +22,24 @@ const LoginNavigator = () => {
     scpoe: 'user_profile,user_media',
     redirectUrl: Config.REDIRECT_URI,
   };
+  const { authorize, user } = useAuth();
+  useLayoutEffect(() => {
+    (async function () {
+      const accessToken = await getData('access-token');
+      const refreshToken = await getData('refresh-token');
+      const isCompletedSignUp = await getData('isCompletedSignUp');
+      if (accessToken && refreshToken && isCompletedSignUp) {
+        authorize({ accessToken, refreshToken, isCompletedSignUp });
+      }
+    })();
+  }, []);
 
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
       }}
+      initialRouteName={user?.isCompletedSignUp ? 'home' : 'login'}
     >
       <Stack.Screen name="login" component={LoginScreen} />
       <Stack.Screen name="register" component={RegisterScreen} options={{ animation: 'slide_from_right' }} />

--- a/packages/climbingapp/src/store/slices/auth.ts
+++ b/packages/climbingapp/src/store/slices/auth.ts
@@ -17,14 +17,14 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    authorize(state, action: PayloadAction<User>) {
+    authorizeAction(state, action: PayloadAction<User>) {
       state.user = action.payload;
     },
-    logout(state) {
+    logoutAction(state) {
       state.user = null;
     },
   },
 });
 
 export default authSlice.reducer;
-export const { authorize, logout } = authSlice.actions;
+export const { authorizeAction, logoutAction } = authSlice.actions;

--- a/packages/climbingapp/src/utils/storage.ts
+++ b/packages/climbingapp/src/utils/storage.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isJsonString } from './isJsonString';
 
 export const storeData = async (key: string, value: any) => {
   try {
@@ -12,7 +13,11 @@ export const getData = async (key: string) => {
   try {
     const value = await AsyncStorage.getItem(key);
     if (value !== null) {
-      return value;
+      if (isJsonString(value)) {
+        return JSON.parse(value);
+      } else {
+        return value;
+      }
     } else {
       return null;
     }


### PR DESCRIPTION
## Related issue
Fixes #188 

## Description
- 앱 내 토큰 저장 및 재실행 시 auto login 적용
- authorize, logout 함수 미동작 버그 fix

## Changes detail
- 토큰 저장
  -  로그인 시  sign-in api  response 를 async storage 에 저장
- 앱 실행 시 토큰 확인
  -  앱 실행 시  navigator에서  useLayoutEffect 사용 (화면 렌더링 전에 토큰 값 확인 후 각각 다른 화면으로 이동)
  -  홈 화면 이동 ( 토큰 존재 & isCompletedSignUp = true)
  - 로그인 화면 이동 (토큰 미존재,  토큰 존재 &   isCompletedSignUp = false)
  
### Checklist

- [ ] Test case
- [x] End of work
