### PR TITLE
[WIP] fix: #191, #190 버그 수정  ( 닉네임 체크, 프로필 사진 S3 업로드)

### DIFF
--- a/packages/climbingapp/src/component/profile-image/ProfileImage.tsx
+++ b/packages/climbingapp/src/component/profile-image/ProfileImage.tsx
@@ -4,35 +4,54 @@ import InstagramIcon from 'climbingapp/src/assets/icon/ic_24_instagram.svg';
 import CameraIcon from 'climbingapp/src/assets/icon/ic_24_camera_gray800.svg';
 import styled from 'styled-components/native';
 import { colorStyles } from 'climbingapp/src/styles';
-import { useImagePicker } from 'climbingapp/src/hooks/useImagePicker';
+
 interface ImageProps {
-    src?: string;
-    icon:
-    | 'insta'
-    | 'camera';
+  src?: string;
+  icon: 'insta' | 'camera';
+  onPress: () => void;
 }
 
 const Image = styled.Image`
-    width: 60px;
-    height: 60px;
-    border-radius: 50px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50px;
 `;
 
 const Conatainer = styled.Pressable`
-    align-items: center;
-    width: 72px;
-    height: 72px;
+  align-items: center;
+  width: 72px;
+  height: 72px;
 `;
 
-export function ProfileImage({ icon }: ImageProps) {
-    const { pickerResponse, selectImage } = useImagePicker();
-    const uri = pickerResponse?.assets ? pickerResponse?.assets[0]?.uri : undefined;
-
-    return (
-        <Conatainer onPress={selectImage} >
-            {uri ? <Image source={{ uri: uri }} resizeMode='cover' resizeMethod='scale' /> : <ProfileSkeleton />}
-            {icon === 'insta' && <InstagramIcon style={{ position: 'absolute', bottom: 0, right: 0, backgroundColor: colorStyles.White }} />}
-            {icon === 'camera' && <CameraIcon style={{ borderRadius: 100, position: 'absolute', bottom: 0, right: 0, backgroundColor: colorStyles.Black }} />}
-        </Conatainer>
-    );
+export function ProfileImage({ icon, src, onPress }: ImageProps) {
+  return (
+    <Conatainer onPress={onPress}>
+      {src ? (
+        <Image source={{ uri: src }} resizeMode="cover" resizeMethod="scale" />
+      ) : (
+        <ProfileSkeleton />
+      )}
+      {icon === 'insta' && (
+        <InstagramIcon
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            right: 0,
+            backgroundColor: colorStyles.White,
+          }}
+        />
+      )}
+      {icon === 'camera' && (
+        <CameraIcon
+          style={{
+            borderRadius: 100,
+            position: 'absolute',
+            bottom: 0,
+            right: 0,
+            backgroundColor: colorStyles.Black,
+          }}
+        />
+      )}
+    </Conatainer>
+  );
 }

--- a/packages/climbingapp/src/hooks/queries/sign/queries.ts
+++ b/packages/climbingapp/src/hooks/queries/sign/queries.ts
@@ -16,7 +16,6 @@ export const uploadProfileImage = async (formData: FormData) => {
     );
     return data;
   } catch (error: any) {
-    console.log(error.response);
     throw error.response.data;
   }
 };

--- a/packages/climbingapp/src/hooks/queries/sign/queries.ts
+++ b/packages/climbingapp/src/hooks/queries/sign/queries.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { UserInfo } from 'climbingapp/src/store/slices/authInfo';
+import { api } from 'climbingapp/src/utils/constants';
+
+const userApi = api + '/users';
+export const uploadProfileImage = async (formData: FormData) => {
+  try {
+    const { data } = await axios.post<string>(
+      userApi + '/me/profile',
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
+    return data;
+  } catch (error: any) {
+    console.log(error.response);
+    throw error.response.data;
+  }
+};
+
+export const signUp = async (userInfo: UserInfo) => {
+  await axios.post(api + '/auth/sign-up', userInfo);
+};

--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -47,7 +47,10 @@ export const useAuth = () => {
       .then((res) => res.data)
       .then(async (res: User) => {
         authorize(res);
-        console.log(res);
+        // 토큰 axios 헤더에 저장
+        axios.defaults.headers.common['access-token'] = res.accessToken;
+        axios.defaults.headers.common['refresh-token'] = res.refreshToken;
+        // 토큰 async storage에 저장
         await storeData('access-token', res.accessToken);
         await storeData('refresh-token', res.refreshToken);
         await storeData(

--- a/packages/climbingapp/src/store/slices/auth.ts
+++ b/packages/climbingapp/src/store/slices/auth.ts
@@ -1,7 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-export interface User {
+
+export interface Token {
   accessToken: string;
   refreshToken: string;
+}
+export interface User extends Token {
   isCompletedSignUp: boolean;
 }
 

--- a/packages/climbingapp/src/store/slices/index.ts
+++ b/packages/climbingapp/src/store/slices/index.ts
@@ -2,10 +2,12 @@ import { combineReducers } from 'redux';
 import auth from './auth';
 import authInfo from './authInfo';
 import webview from './webview';
+import s3util from './s3util';
 const rootReducer = combineReducers({
   auth,
   authInfo,
   webview,
+  s3util,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/packages/climbingapp/src/store/slices/s3util.ts
+++ b/packages/climbingapp/src/store/slices/s3util.ts
@@ -1,0 +1,21 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Asset } from 'react-native-image-picker';
+
+export interface S3Util {
+  profileImage?: Asset;
+}
+
+const initialState: S3Util = {};
+
+const S3UtilSlice = createSlice({
+  name: 'S3Util',
+  initialState,
+  reducers: {
+    setProfileImageFile(state, action: PayloadAction<Asset>) {
+      state.profileImage = action.payload;
+    },
+  },
+});
+
+export default S3UtilSlice.reducer;
+export const { setProfileImageFile } = S3UtilSlice.actions;

--- a/packages/climbingapp/src/utils/constants.ts
+++ b/packages/climbingapp/src/utils/constants.ts
@@ -2,6 +2,8 @@ import Config from 'react-native-config';
 
 export const api = Config.API + '/api/v1';
 
+export const defaultImage = Config.DEFAULT_IMAGE;
+
 export const injectedScriptForWebViewBackButton = `
 (function() {
   function wrap(fn) {

--- a/packages/climbingapp/src/utils/errorMessage.ts
+++ b/packages/climbingapp/src/utils/errorMessage.ts
@@ -1,0 +1,4 @@
+export const errorMessage = {
+  IMAGE_UPLOAD_ERROR: '이미지 업로드에 실패했습니다.',
+  SERVER_ERROR: '서버에 문제가 있습니다. 잠시 후 다시 시도해주세요.',
+};


### PR DESCRIPTION
## Related issue
Fixes #191 #190 

## Description
- 닉네임 체크 로직 수정
- 프로필 사진 업로드 기능 추가
  -  프로필 사진 S3 업로드 api 추가 

## Changes detail
- 닉네임 중복 체크 로직은 요구사항과 다르게 api가 인풋의 입력에 따라 바로 호출되도록 함,  
  -  버튼이 닉네임 미입력 시 disabled 되어야 하는데 버튼을 누를 때 닉네임 중복을 체크한다는 것은 어색함
- 프로필 업로드 기능 추가
  -  프로필 이미지 파일 path S3utils. 슬라이스에 저장 
  - sign-up api 호출 전 이미지 업로드 api 먼저 수행 후 성공 시 진행하도록 로직 적용
- 로그인 인증 시 axios header에 토큰 저장
- 
## screenShot
- 닉네임 체크 로직 동작 화면
![닉네임중복](https://user-images.githubusercontent.com/33804074/216827142-407ce50d-4be4-4476-881f-f4cbf38bbbfc.gif)


### Checklist

- [ ] Test case
- [x] End of work
