### PR TITLE
fix: android 가로모드 고정, pinch zoom 막기, user-select (텍스트 복사 등) 막기 적용

### DIFF
--- a/packages/climbingapp/android/app/src/main/AndroidManifest.xml
+++ b/packages/climbingapp/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+        android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustPan"

--- a/packages/climbingapp/src/component/webview/CustomWebView.tsx
+++ b/packages/climbingapp/src/component/webview/CustomWebView.tsx
@@ -73,6 +73,7 @@ export default function CustomWebView({ url }: WebInfo) {
   return (
     <>
       <WebView
+        setBuiltInZoomControls={false}
         ref={webviewRef}
         onLoad={sendTokenToWebview}
         onMessage={onMessageHandler}

--- a/packages/climbingapp/src/utils/constants.ts
+++ b/packages/climbingapp/src/utils/constants.ts
@@ -19,5 +19,10 @@ export const injectedScriptForWebViewBackButton = `
   });
 })();
 
+document.body.style.userSelect = 'none'
 true;
 `;
+
+// webview css
+// user-select:  none;
+//


### PR DESCRIPTION
## Related issue
Fixes #77 

## Description
- 앱 내  웹뷰 환경의 자연스러움을 위한 스타일 적용
- 앱 코드 내에서 적용
- 참고 자료
  -  https://shylog.com/settings-for-a-more-complete-webview/
  - 
## Changes detail
- android 가로모드 고정
- webview component 속성 적용
  -  유저가 pinch zoom in, out 을 하지 못하게 설정
  - javascript 삽입
    -  user-select 속성 none 적용  (텍스트 드래그 불가) 

### Checklist

- [ ] Test case
- [x] End of work
