### PR TITLE
fix: redux 비동기 상태 체크 적용 => auto 로그인 분기처리 로직수정

### DIFF
--- a/packages/climbingapp/src/hooks/useGetTokenFromStorage.ts
+++ b/packages/climbingapp/src/hooks/useGetTokenFromStorage.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../store/slices';
+import { getTokenFromStorage } from '../store/slices/auth';
+
+export const useGetTokenFromStorage = () => {
+  const dispatch = useDispatch();
+  const { loading } = useSelector((state: RootState) => state.auth);
+
+  useEffect(() => {
+    dispatch(getTokenFromStorage());
+  }, []);
+
+  return { loading };
+};

--- a/packages/climbingapp/src/navigation/LoginNavigator.tsx
+++ b/packages/climbingapp/src/navigation/LoginNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from './screens/auth/LoginScreen';
 import RegisterScreen from './screens/auth/RegisterScreen';
@@ -11,8 +11,8 @@ import InstagramAuthWebView from '../component/webview/InstagramAuthWebview';
 import Config from 'react-native-config';
 import SignUpStepTwoScreen from './screens/auth/SignUpStepTwoScreen';
 import HomeScreen from './screens/main/HomeScreen';
-import { getData } from '../utils/storage';
 import { useAuth } from '../hooks/useAuth';
+import { useGetTokenFromStorage } from '../hooks/useGetTokenFromStorage';
 const Stack = createNativeStackNavigator();
 
 const LoginNavigator = () => {
@@ -22,17 +22,13 @@ const LoginNavigator = () => {
     scpoe: 'user_profile,user_media',
     redirectUrl: Config.REDIRECT_URI,
   };
-  const { authorize, user } = useAuth();
-  useLayoutEffect(() => {
-    (async function () {
-      const accessToken = await getData('access-token');
-      const refreshToken = await getData('refresh-token');
-      const isCompletedSignUp = await getData('isCompletedSignUp');
-      if (accessToken && refreshToken && isCompletedSignUp) {
-        authorize({ accessToken, refreshToken, isCompletedSignUp });
-      }
-    })();
-  }, []);
+  const { user } = useAuth();
+  const { loading } = useGetTokenFromStorage();
+
+  if (loading) {
+    // 추후 스플래시 이미지 추가
+    return null;
+  }
 
   return (
     <Stack.Navigator


### PR DESCRIPTION
## Description
- auto login 기능 화면 플로우 버그 수정

## Changes detail
-  useLayoutEffect 제거 (  디바이스에서 토큰을 가져오기 전에 화면 분기 처리 로직이 진행되어서 버그 발생)
-  redux-thunk 사용
  - 디바이스에 저장된 토큰을 가져올 때 비동기로 불러옴, 이를 판단할 수 있는 loading 상태가 필요
  - useGetTokenFromStorage 훅을 작성해 해당 로직을 관리

## ScreenShot
![auto-login](https://user-images.githubusercontent.com/33804074/217178825-4270ca22-42a8-4505-8b33-4ea0cb635a03.gif)



### Checklist
- [ ] Test case
- [X] End of work
