### PR TITLE
refac&fix: #212, #214 버그 fix 와 useMutation custom hooks 리팩터링

### DIFF
--- a/packages/climbingweb/pages/feed/create/index.tsx
+++ b/packages/climbingweb/pages/feed/create/index.tsx
@@ -40,7 +40,7 @@ export default function CreatePostPage() {
       alert('입력 완료 되었습니다.');
       router.push('/');
     },
-    onError: (error) => {
+    onError: () => {
       alert('피드 작성에 실패했습니다. 다시 시도해주세요.');
       window.location.reload();
     },

--- a/packages/climbingweb/pages/feed/create/index.tsx
+++ b/packages/climbingweb/pages/feed/create/index.tsx
@@ -19,6 +19,7 @@ import {
   useFindHoldInfoByCenter,
   useSearchCenterName,
 } from 'climbingweb/src/hooks/queries/center/queryKey';
+import { useRouter } from 'next/router';
 
 export default function CreatePostPage() {
   const [page, setPage] = useState<string>('first');
@@ -29,11 +30,21 @@ export default function CreatePostPage() {
   const [searchInput, setSearchInput] = useState<string>('');
   const [selected, setSelected] = useState(false);
   const { data: centerList } = useSearchCenterName(searchInput);
+  const router = useRouter();
 
   //기준이 되는 hold 리스트 state
   const { data: holdListData } = useFindHoldInfoByCenter(postData.centerId);
 
-  const { isLoading } = useCreatePost();
+  const { isLoading } = useCreatePost({
+    onSuccess: () => {
+      alert('입력 완료 되었습니다.');
+      router.push('/');
+    },
+    onError: (error) => {
+      alert('피드 작성에 실패했습니다. 다시 시도해주세요.');
+      window.location.reload();
+    },
+  });
   const { mutate: getPostContentsList, isLoading: getPostContentsListLoading } =
     useGetPostContentsList();
 

--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -31,6 +31,9 @@ export default function ReportPage({}) {
     onSuccess: () => {
       toast('입력 완료 되었습니다.');
     },
+    onError: () => {
+      toast('신고글 게시에 실패하였습니다.');
+    },
   });
 
   //바텀 시트 open/ close handler

--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -27,18 +27,11 @@ export default function ReportPage({}) {
     '부적절한 게시글' | '부적절한 닉네임' | '잘못된 암장 선택'
   >('부적절한 게시글');
 
-  const { mutate: createCenterReportMutate, isSuccess } = useCreateReport(
-    feedId,
-    {
-      onSuccess: () => {
-        if (isSuccess) {
-          toast('입력 완료 되었습니다.');
-        } else {
-          toast('입력 실패 하였습니다.');
-        }
-      },
-    }
-  );
+  const { mutate: createCenterReportMutate } = useCreateReport(feedId, {
+    onSuccess: () => {
+      toast('입력 완료 되었습니다.');
+    },
+  });
 
   //바텀 시트 open/ close handler
   const handleOpen = () => {

--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -27,8 +27,18 @@ export default function ReportPage({}) {
     '부적절한 게시글' | '부적절한 닉네임' | '잘못된 암장 선택'
   >('부적절한 게시글');
 
-  const { mutate: createCenterReportMutate, isSuccess } =
-    useCreateReport(feedId);
+  const { mutate: createCenterReportMutate, isSuccess } = useCreateReport(
+    feedId,
+    {
+      onSuccess: () => {
+        if (isSuccess) {
+          toast('입력 완료 되었습니다.');
+        } else {
+          toast('입력 실패 하였습니다.');
+        }
+      },
+    }
+  );
 
   //바텀 시트 open/ close handler
   const handleOpen = () => {
@@ -53,11 +63,6 @@ export default function ReportPage({}) {
         reportType: reportType,
         content: contentInputRef.current.value,
       });
-      if (isSuccess) {
-        toast('입력 완료 되었습니다.');
-      } else {
-        toast('입력 실패 하였습니다.');
-      }
     }
   };
 

--- a/packages/climbingweb/pages/users/name/[uname]/index.tsx
+++ b/packages/climbingweb/pages/users/name/[uname]/index.tsx
@@ -20,16 +20,22 @@ import {
   useCreateBlock,
   useFindPostsByUser,
   useGetPublicUser,
+  userQueries,
 } from 'climbingweb/src/hooks/queries/user/queryKey';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
+import { useToast } from 'climbingweb/src/hooks/useToast';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { BottomSheet } from 'react-spring-bottom-sheet';
 
 export default function UserPage({}) {
   const router = useRouter();
   const { uname } = router.query;
   const userNickname = uname as string;
+  const queryClient = useQueryClient();
+
+  const { toast } = useToast();
 
   //바텀 시트 on/off state
   const [openSheet, setOpenSheet] = useState<boolean>(false);
@@ -52,10 +58,20 @@ export default function UserPage({}) {
   } = useFindPostsByUser(userNickname);
 
   // 라온 신청 useMutation
-  const { mutate: createLaonMutate } = useCreateLaon();
+  const { mutate: createLaonMutate } = useCreateLaon({
+    onSuccess: () => {
+      toast('라온 신청하였습니다.');
+      queryClient.invalidateQueries(userQueries.name(userNickname));
+    },
+  });
 
   // 라온 취소 useMutation
-  const { mutate: deleteLaonMutate } = useDeleteLaon();
+  const { mutate: deleteLaonMutate } = useDeleteLaon({
+    onSuccess: () => {
+      toast('라온 취소하였습니다.');
+      queryClient.invalidateQueries(userQueries.name(userNickname));
+    },
+  });
 
   // 차단 useMutation
   const { mutate: createBlockMutate } = useCreateBlock();

--- a/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
+++ b/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
@@ -26,6 +26,9 @@ const UserResult = ({ imagePath, isLaon, nickname }: UserProps) => {
       toast('라온 신청하였습니다.');
       setButtonDisabled(true);
     },
+    onError: () => {
+      toast('라온 신청에 실패하였습니다.');
+    },
   });
 
   // 라온 신청 버튼 클릭 핸들링 함수

--- a/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
+++ b/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { UserResultSkeleton } from '../../common/skeleton/UserResultSkeleton';
 import { ProfileImage } from '../../common/profileImage/ProfileImage';
+import { useToast } from 'climbingweb/src/hooks/useToast';
 
 interface UserProps {
   imagePath: string;
@@ -16,9 +17,14 @@ interface UserProps {
  */
 const UserResult = ({ imagePath, isLaon, nickname }: UserProps) => {
   const router = useRouter();
+  const { toast } = useToast();
 
   //라온 신청 mutation
-  const { mutate: createLaonMutate } = useCreateLaon();
+  const { mutate: createLaonMutate } = useCreateLaon({
+    onSuccess: () => {
+      toast('라온 신청하였습니다.');
+    },
+  });
 
   // 라온 신청 버튼 클릭 핸들링 함수
   const handleRaonButtonClick = () => {

--- a/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
+++ b/packages/climbingweb/src/components/SearchResult/UserResult/UserResult.tsx
@@ -1,6 +1,6 @@
 import { useCreateLaon } from 'climbingweb/src/hooks/queries/laon/queryKey';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useState } from 'react';
 import { UserResultSkeleton } from '../../common/skeleton/UserResultSkeleton';
 import { ProfileImage } from '../../common/profileImage/ProfileImage';
 import { useToast } from 'climbingweb/src/hooks/useToast';
@@ -18,11 +18,13 @@ interface UserProps {
 const UserResult = ({ imagePath, isLaon, nickname }: UserProps) => {
   const router = useRouter();
   const { toast } = useToast();
+  const [buttonDisabled, setButtonDisabled] = useState<boolean>(isLaon);
 
   //라온 신청 mutation
   const { mutate: createLaonMutate } = useCreateLaon({
     onSuccess: () => {
       toast('라온 신청하였습니다.');
+      setButtonDisabled(true);
     },
   });
 
@@ -48,7 +50,7 @@ const UserResult = ({ imagePath, isLaon, nickname }: UserProps) => {
       <button
         className="absolute bg-purple-500 text-center bottom-0 my-[6px] w-[36px] h-[16px] rounded-full text-white disabled:bg-slate-400"
         onClick={handleRaonButtonClick}
-        disabled={isLaon}
+        disabled={buttonDisabled}
       >
         라온
       </button>

--- a/packages/climbingweb/src/hooks/queries/center/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/center/queryKey.ts
@@ -14,8 +14,6 @@ import {
   useQuery,
   useQueryClient,
   useInfiniteQuery,
-  UseQueryOptions,
-  QueryKey,
   UseMutationOptions,
 } from 'react-query';
 import {

--- a/packages/climbingweb/src/hooks/queries/center/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/center/queryKey.ts
@@ -80,14 +80,9 @@ export const centerQueries = createQueryKeys('centers', {
 export const useGetCenterList = (
   option: 'bookmark' | 'new_setting' | 'newly_registered'
 ) => {
-  return useInfiniteQuery({
+  return useQuery({
     ...centerQueries.list(option),
     enabled: Boolean(option),
-    getNextPageParam: (lastPageData) => {
-      return lastPageData.nextPageNum < 0
-        ? undefined
-        : lastPageData.nextPageNum;
-    },
   });
 };
 

--- a/packages/climbingweb/src/hooks/queries/laon/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/laon/queryKey.ts
@@ -1,5 +1,10 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
-import { useInfiniteQuery, useMutation, useQueryClient } from 'react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from 'react-query';
 import { createLaon, deleteLaon, findAllLaon, getLaonPost } from './queries';
 
 /**
@@ -35,12 +40,22 @@ export const useFindAllLaon = () => {
 /**
  * createLaon api (라온 생성) 의 useMutation hooks
  *
+ * @param options useMutation 추가 옵션
  * @returns createLaon api (라온 생성) 의 useMutation return 값
  */
-export const useCreateLaon = () => {
+export const useCreateLaon = (
+  options?: Omit<
+    UseMutationOptions<void, unknown, string, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(createLaon, {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries({
         queryKey: laonQueries.list().queryKey,
         refetchInactive: true,
@@ -52,12 +67,22 @@ export const useCreateLaon = () => {
 /**
  * deleteLaon api (라온 삭제) 의 useMutation hooks
  *
+ * @param options useMutation 추가 옵션
  * @returns deleteLaon api (라온 삭제) 의 useMutation return 값
  */
-export const useDeleteLaon = () => {
+export const useDeleteLaon = (
+  options?: Omit<
+    UseMutationOptions<void, unknown, string, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(deleteLaon, {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries({
         queryKey: laonQueries.list().queryKey,
         refetchInactive: true,

--- a/packages/climbingweb/src/hooks/queries/post/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queryKey.ts
@@ -12,6 +12,9 @@ import {
   useQueryClient,
   useInfiniteQuery,
   useQuery,
+  UseMutationOptions,
+  UseInfiniteQueryOptions,
+  QueryKey,
 } from 'react-query';
 import {
   createComment,
@@ -27,7 +30,13 @@ import {
   getPosts,
   updateComment,
 } from './queries';
-import { PostContents } from 'climbingweb/types/response/post';
+import {
+  CommentResponse,
+  LikeResponse,
+  PostContents,
+  PostReportResponse,
+  PostResponse,
+} from 'climbingweb/types/response/post';
 import { useRouter } from 'next/router';
 
 /**
@@ -64,12 +73,23 @@ export const postQueries = createQueryKeys('posts', {
  * createLike api useMutation hooks
  *
  * @param postId 좋아요를 누를 post id
+ * @param options 추가적인 옵션
  * @returns createLike api useMutation return 값
  */
-export const useCreateLike = (postId: string) => {
+export const useCreateLike = (
+  postId: string,
+  options?: Omit<
+    UseMutationOptions<LikeResponse, unknown, void, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(() => createLike(postId), {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries({
         queryKey: postQueries.list().queryKey,
         refetchInactive: true,
@@ -90,12 +110,23 @@ export const useCreateLike = (postId: string) => {
  * deleteLike api useMutation hooks
  *
  * @param postId 좋아요를 취소할 post id
+ * @param options 추가적인 옵션
  * @returns deleteLike api useMutation return 값
  */
-export const useDeleteLike = (postId: string) => {
+export const useDeleteLike = (
+  postId: string,
+  options?: Omit<
+    UseMutationOptions<LikeResponse, unknown, void, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(() => deleteLike(postId), {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries({
         queryKey: postQueries.list().queryKey,
         refetchInactive: true,
@@ -116,26 +147,28 @@ export const useDeleteLike = (postId: string) => {
  * createPost api useMutation hooks
  *
  * @param postCreateRequest 게시할 피드 내용
+ * @param options 추가적인 옵션
  * @returns createPost api useMutation return 값
  */
-export const useCreatePost = () => {
-  const router = useRouter();
+export const useCreatePost = (
+  options?: Omit<
+    UseMutationOptions<PostResponse, unknown, PostCreateRequest, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(
     (postCreateRequest: PostCreateRequest) => createPost(postCreateRequest),
     {
-      onSuccess: () => {
+      ...options,
+      onSuccess: (data, variables, context) => {
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
         queryClient.invalidateQueries({
           queryKey: postQueries.list().queryKey,
           refetchInactive: true,
         });
-        alert('입력 완료 되었습니다.');
-        router.push('/');
-      },
-      onError: (error) => {
-        console.error(error);
-        alert('피드 작성에 실패했습니다. 다시 시도해주세요.');
-        window.location.reload();
       },
     }
   );
@@ -207,15 +240,30 @@ export const useGetPosts = () => {
  * createComment api useMutation hooks
  *
  * @param postId 댓글을 달 게시글의 id
+ * @param options 추가적인 옵션
  * @returns createComment api useMutation return 값
  */
-export const useCreateComment = (postId: string) => {
+export const useCreateComment = (
+  postId: string,
+  options?: Omit<
+    UseMutationOptions<
+      CommentCreateRequest,
+      unknown,
+      CommentCreateRequest,
+      unknown
+    >,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(
     (commentCreateRequest: CommentCreateRequest) =>
       createComment(postId, commentCreateRequest),
     {
-      onSuccess: () => {
+      onSuccess: (data, variables, context) => {
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
         queryClient.invalidateQueries({
           queryKey: postQueries.detail(postId).queryKey,
           refetchInactive: true,
@@ -230,15 +278,31 @@ export const useCreateComment = (postId: string) => {
  *
  * @param postId 댓글을 달 게시글의 id
  * @param parentId 댓글의 답글을 달 comment id
+ * @param options 추가적인 옵션
  * @returns createChildComment api useMutation return 값
  */
-export const useCreateChildComment = (postId: string, parentId: string) => {
+export const useCreateChildComment = (
+  postId: string,
+  parentId: string,
+  options?: Omit<
+    UseMutationOptions<
+      CommentCreateRequest,
+      unknown,
+      CommentCreateRequest,
+      unknown
+    >,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(
     (commentCreateRequest: CommentCreateRequest) =>
       createComment(postId, commentCreateRequest),
     {
-      onSuccess: () => {
+      onSuccess: (data, variables, context) => {
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
         queryClient.invalidateQueries({
           queryKey: postQueries.childrenComment(parentId).queryKey,
           refetchInactive: true,
@@ -252,19 +316,32 @@ export const useCreateChildComment = (postId: string, parentId: string) => {
  * updateComment api useMutation hooks
  *
  * @param commentId 수정할 댓글의 id
+ * @param options 추가적인 옵션
  * @returns updateComment api useMutation return 값
  */
 export const useUpdateComment = (
   postId: string,
   commentId: string,
-  parentId?: string
+  parentId?: string,
+  options?: Omit<
+    UseMutationOptions<
+      CommentUpdateRequest,
+      unknown,
+      CommentUpdateRequest,
+      unknown
+    >,
+    'mutationFn'
+  >
 ) => {
   const queryClient = useQueryClient();
   return useMutation(
     (commentUpdateRequest: CommentUpdateRequest) =>
       updateComment(commentId, commentUpdateRequest),
     {
-      onSuccess: () => {
+      onSuccess: (data, variables, context) => {
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
         queryClient.invalidateQueries({
           queryKey: postQueries.detail(postId).queryKey,
           refetchInactive: true,
@@ -284,16 +361,24 @@ export const useUpdateComment = (
  * deleteComment api useMutation hooks
  *
  * @param commentId 삭제할 댓글의 id
+ * @param options 추가적인 옵션
  * @returns deleteComment api useMutation return 값
  */
 export const useDeleteComment = (
   postId: string,
   commentId: string,
-  parentId?: string
+  parentId?: string,
+  options?: Omit<
+    UseMutationOptions<CommentResponse, unknown, void, unknown>,
+    'mutationFn'
+  >
 ) => {
   const queryClient = useQueryClient();
   return useMutation(() => deleteComment(commentId), {
-    onSuccess: () => {
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries({
         queryKey: postQueries.detail(postId).queryKey,
         refetchInactive: true,
@@ -308,9 +393,25 @@ export const useDeleteComment = (
   });
 };
 
-export const useCreateReport = (postId: string) => {
-  return useMutation((reportData: PostReportRequest) =>
-    createReport(postId, reportData)
+/**
+ * createReport api useMutation hooks
+ *
+ * @param postId 신고할 게시글 id
+ * @param options
+ * @returns
+ */
+export const useCreateReport = (
+  postId: string,
+  options?: Omit<
+    UseMutationOptions<PostReportResponse, unknown, PostReportRequest, unknown>,
+    'mutationFn'
+  >
+) => {
+  return useMutation(
+    (reportData: PostReportRequest) => createReport(postId, reportData),
+    {
+      ...options,
+    }
   );
 };
 

--- a/packages/climbingweb/src/hooks/queries/post/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queryKey.ts
@@ -13,8 +13,6 @@ import {
   useInfiniteQuery,
   useQuery,
   UseMutationOptions,
-  UseInfiniteQueryOptions,
-  QueryKey,
 } from 'react-query';
 import {
   createComment,

--- a/packages/climbingweb/src/hooks/queries/post/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queryKey.ts
@@ -35,7 +35,6 @@ import {
   PostReportResponse,
   PostResponse,
 } from 'climbingweb/types/response/post';
-import { useRouter } from 'next/router';
 
 /**
  * 추후 성능 개선 필요!!

--- a/packages/climbingweb/src/hooks/queries/user/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/user/queryKey.ts
@@ -1,7 +1,10 @@
+import { UserRequest } from 'climbingweb/types/request/user';
+import { PublicScopeResponse } from './../../../../types/response/user/index.d';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
   useInfiniteQuery,
   useMutation,
+  UseMutationOptions,
   useQuery,
   useQueryClient,
 } from 'react-query';
@@ -54,12 +57,22 @@ export const userQueries = createQueryKeys('users', {
 /**
  * changePublicScope api (회원 정보 공개 변경) 의 useMutation hooks
  *
+ * @param options useMutation 추가 옵션
  * @returns changePublicScope api (회원 정보 공개 변경) 의 useMutation return 값
  */
-export const useChangePublicScope = () => {
+export const useChangePublicScope = (
+  options?: Omit<
+    UseMutationOptions<PublicScopeResponse, unknown, void, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(changePublicScope, {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries(userQueries.me());
     },
   });
@@ -68,12 +81,22 @@ export const useChangePublicScope = () => {
 /**
  * createBlock api (회원 차단) 의 useMutation hooks
  *
+ * @param options useMutation 추가 옵션
  * @returns createBlock api (회원 차단) 의 useMutation return 값
  */
-export const useCreateBlock = () => {
+export const useCreateBlock = (
+  options?: Omit<
+    UseMutationOptions<void, unknown, string, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(createBlock, {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries(userQueries.block());
     },
   });
@@ -82,12 +105,22 @@ export const useCreateBlock = () => {
 /**
  * deleteBlock api (차단 삭제) 의 useMutation hooks
  *
+ * @param options useMutation 추가 옵션
  * @returns deleteBlock api (차단 삭제) 의 useMutation return 값
  */
-export const useDeleteBlock = () => {
+export const useDeleteBlock = (
+  options?: Omit<
+    UseMutationOptions<void, unknown, string, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(createBlock, {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries(userQueries.block());
     },
   });
@@ -143,12 +176,22 @@ export const useGetPublicUser = (nickname: string) => {
 /**
  * modifyUser api (회원 정보 수정) 의 useMutation hooks
  *
+ * @param options useMutation 추가 옵션
  * @returns modifyUser api (회원 정보 수정) 의 useMutation return 값
  */
-export const useModifyUser = () => {
+export const useModifyUser = (
+  options?: Omit<
+    UseMutationOptions<any, unknown, UserRequest, unknown>,
+    'mutationFn'
+  >
+) => {
   const queryClient = useQueryClient();
   return useMutation(modifyUser, {
-    onSuccess: () => {
+    ...options,
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
       queryClient.invalidateQueries(userQueries.me());
     },
   });


### PR DESCRIPTION
## Related issue
#212 #214 

## Description
refac&fix: #212, #214 버그 fix 와 useMutation custom hooks 기본 options 사용 가능하도록 리팩터링
버그를 해결하기 위해 기본 options 사용 가능하도록 지원이 필요해서 리팩터링을 같이 진행함

## Changes detail

- #212 라온 신청
  ![#212 리포트](https://user-images.githubusercontent.com/37992140/218289274-2b2db151-00be-4430-bbf9-ec98cb9bdd71.gif)
  1. 라온 신청 시, 버튼 disabled 변경 처리가 되지 않은 점 수정
  2. 라온 신청 성공 시, 신청 완료 toast 추가
  3. 라온 신청 실패 시, 신청 실패 toast 추가
- #214 게시글 신고 버스
  1. 버그 게시글 작성 성공 시, 신청 완료 toast 추가
  2. 버그 게시글 작성 실패 시, 신청 실패 toast 추가
- useMutation custom hooks 리팩터링
  1. hooks/queries/center/queryKey.ts 변경사항
      useMutation 을 사용하는 custom hooks 가 tanstack query 의 기본 useMutation options 를 사용 할 수 있도록 변경
  2. hooks/queries/laon/queryKey.ts 변경사항
      useMutation 을 사용하는 custom hooks 가 tanstack query 의 기본 useMutation options 를 사용 할 수 있도록 변경
  3. hooks/queries/post/queryKey.ts 변경사항
      useMutation 을 사용하는 custom hooks 가 tanstack query 의 기본 useMutation options 를 사용 할 수 있도록 변경
      * useCreatePost 에 있던 onSuccess 로직을 컴포넌트 부분으로 뺌 @qowlsdn8007 
  4. hooks/queries/user/queryKey.ts 변경사항
      useMutation 을 사용하는 custom hooks 가 tanstack query 의 기본 useMutation options 를 사용 할 수 있도록 변경

### Checklist

- [ ] Test case
- [ ] End of work
