### PR TITLE
fix: 댓글 더보기 클릭시 버그

### DIFF
--- a/packages/climbingweb/src/components/HomeFeed/FeedContent/FeedContent.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/FeedContent/FeedContent.tsx
@@ -73,12 +73,14 @@ const FeedContent = ({
         <p className="py-2 font-medium pl-[6px]">{content}</p>
       )}
       {
-        <p
-          onTouchEnd={onClickMoreComment}
-          className="font-medium text-[#BFBFBF] text-sm pl-[6px]"
-        >
-          {replyCount === 0 ? '댓글 달기' : `댓글 ${replyCount}개 더 보기`}
-        </p>
+        <div className="flex">
+          <p
+            onTouchEnd={onClickMoreComment}
+            className="font-medium text-gray-400"
+          >
+            {replyCount === 0 ? '댓글 달기' : `댓글 ${replyCount}개 더 보기`}
+          </p>
+        </div>
       }
     </section>
   );


### PR DESCRIPTION
## Related issue
Fixes #226 

## Description
댓글 더보기 같은 라인의 빈 공간을 클릭 했을 경우에도 댓글 창으로 가는 버그 수정

## Changes detail

- 댓글 더보기를 div로 감싸 display flex 속성 추가


 
![localhost_3000-Chrome-2023-02-13-15-20-18](https://user-images.githubusercontent.com/42572954/218388064-a647cae1-267b-458e-abe4-93f38684c4f7.gif)


### Checklist

- [ ] Test case
- [ ] End of work
