### PR TITLE
feature: #게시글_상세_메뉴 #게시글_상세_메뉴_삭제

### DIFF
--- a/packages/climbingweb/src/components/common/BottomSheetContents/ButtonSheet/index.tsx
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/ButtonSheet/index.tsx
@@ -7,11 +7,15 @@ export const ButtonSheet = ({
   text,
 }: ConfirmSheetProps) => {
   return (
-    <div className="flex flex-col gap-6 mb-4 p-4">
+    <div className="flex flex-col gap-[10px] pt-[10px] pb-[20px] px-[15px]">
       <p className="text-base text-gray-600 font-normal text-center">{text}</p>
-      <div className="flex flex-row justify-center text-center text-base font-bold px-4 gap-4">
-        <WhiteButton onClick={onCancel}>취소</WhiteButton>
-        <NormalButton onClick={onConfirm}>확인</NormalButton>
+      <div className="flex flex-row justify-center text-center text-base font-bold gap-4 h-[5.6vh]">
+        <WhiteButton className="h-[5.6vh] text-base" onClick={onCancel}>
+          취소
+        </WhiteButton>
+        <NormalButton className="h-[5.6vh] text-base" onClick={onConfirm}>
+          확인
+        </NormalButton>
       </div>
     </div>
   );

--- a/packages/climbingweb/src/components/common/button/Button.tsx
+++ b/packages/climbingweb/src/components/common/button/Button.tsx
@@ -2,12 +2,18 @@ interface ButtonProps {
   onClick?: ({}: any) => void;
   children?: React.ReactNode | React.ReactNode[];
   disabled?: boolean;
+  className?: string;
 }
 
-export const NormalButton = ({ onClick, children, disabled }: ButtonProps) => {
+export const NormalButton = ({
+  onClick,
+  children,
+  disabled,
+  className,
+}: ButtonProps) => {
   return (
     <button
-      className="w-full bg-purple-500 rounded-lg w-30 h-[56px] text-white active:bg-purple-400 disabled:bg-gray-300 disabled:text-gray-500"
+      className={`w-full bg-purple-500 rounded-lg w-30 h-[56px] text-white active:bg-purple-400 disabled:bg-gray-300 disabled:text-gray-500 ${className}`}
       disabled={disabled}
       onTouchEnd={onClick}
     >
@@ -16,10 +22,10 @@ export const NormalButton = ({ onClick, children, disabled }: ButtonProps) => {
   );
 };
 
-export const WhiteButton = ({ onClick, children }: ButtonProps) => {
+export const WhiteButton = ({ onClick, children, className }: ButtonProps) => {
   return (
     <button
-      className="w-full bg-gray-100 rounded-lg w-30 h-12 text-black active:bg-gray-200"
+      className={`w-full bg-gray-100 rounded-lg w-30 h-12 text-black active:bg-gray-200 ${className}`}
       onTouchEnd={onClick}
     >
       {children}

--- a/packages/climbingweb/src/hooks/queries/post/queries.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queries.ts
@@ -1,6 +1,7 @@
 import {
   ChildCommentResponse,
   CommentResponse,
+  PostDeleteResponse,
 } from './../../../../types/response/post/index.d';
 import axios from 'axios';
 import { Pagination } from 'climbingweb/types/common';
@@ -228,6 +229,23 @@ export const deleteComment = async (commentId: string) => {
     throw error.response.data;
   }
 };
+
+
+/**
+ * Delete /api/v1/posts/{postId} api query 함수
+ * 
+ * @param postId 
+ * @returns axiosResponse.data   
+ */
+export const deletePost = async (postId: string) => {
+  try {
+    const { data } = await axios.delete<PostDeleteResponse>(`/posts/${postId}`);
+    return data;
+  } catch (error: any) {
+    throw error.response.data;
+  }
+};
+
 export const getPostContentsList = async (fileList: File[]) => {
   const data = await axios
     .all(

--- a/packages/climbingweb/src/hooks/queries/post/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/post/queryKey.ts
@@ -27,6 +27,7 @@ import {
   getPost,
   getPosts,
   updateComment,
+  deletePost,
 } from './queries';
 import { useRouter } from 'next/router';
 import { useToast } from '../../useToast';
@@ -34,6 +35,7 @@ import {
   CommentResponse,
   LikeResponse,
   PostContents,
+  PostDeleteResponse,
   PostReportResponse,
   PostResponse,
 } from 'climbingweb/types/response/post';
@@ -178,7 +180,6 @@ export const useCreatePost = (
         console.error(error);
         toast('피드 작성에 실패했습니다. 다시 시도해주세요.');
         window.location.reload();
-
       },
     }
   );
@@ -400,6 +401,35 @@ export const useDeleteComment = (
         });
       }
     },
+  });
+};
+
+/**
+ * delete post api useMutation hooks
+ *
+ * @param postId
+ * @param options
+ * @returns
+ */
+export const useDeletePost = (
+  postId: string,
+  options?: Omit<
+    UseMutationOptions<PostDeleteResponse, unknown, void, unknown>,
+    'mutationFn'
+  >
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(() => deletePost(postId), {
+    onSuccess: (data, variables, context) => {
+      if (options?.onSuccess) {
+        options.onSuccess(data, variables, context);
+      }
+      queryClient.invalidateQueries({
+        queryKey: ['delete', postId],
+        refetchInactive: true,
+      });
+    },
+    ...options
   });
 };
 

--- a/packages/climbingweb/types/response/post/index.d.ts
+++ b/packages/climbingweb/types/response/post/index.d.ts
@@ -27,6 +27,20 @@ export interface PostDetailResponse {
   userProfile: string;
 }
 
+export interface PostDeleteResponse {
+  centerId: string;
+  centerName: string;
+  climbingHistories: ClimbingHistoryResponse[];
+  content: string;
+  contentList: string[];
+  createdAt: string;
+  isDeleted: boolean;
+  likeCount: number;
+  postId: string;
+  userNickname: string;
+  userProfile: string;
+}
+
 export interface PostContents {
   url: string;
 }


### PR DESCRIPTION
## Related issue
Fixes #232

## Description

## Changes detail

- 게시글 상세 메뉴 클릭시 본인이 작성한 피드일 경우 수정 및 삭제 메뉴 표시
- 게시글 삭제 메뉴 추가


![#게시글_상세_메뉴](https://user-images.githubusercontent.com/42572954/218663535-992b9b10-f5bd-4b4a-8ac9-645b4079071a.JPG)
![#게시글_상세_메뉴_삭제](https://user-images.githubusercontent.com/42572954/218663545-62f46484-73d0-44b8-b033-d24383c354c8.JPG)
![#삭제완료](https://user-images.githubusercontent.com/42572954/218663547-939eb46c-e528-4a07-b504-669d60e44413.JPG)


### Checklist

- [ ] Test case
- [ ] End of work
