### PR TITLE
fix: #227 댓글 인풋창 버그 해결

### DIFF
--- a/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
@@ -15,6 +15,7 @@ import {
   useFindAllParentComment,
   useUpdateComment,
 } from 'climbingweb/src/hooks/queries/post/queryKey';
+import { useBnbHide } from 'climbingweb/src/hooks/useBnB';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
 import {
   CommentCreateRequest,
@@ -35,6 +36,8 @@ export default function CommentDetailPage() {
   const { fid, cid } = router.query;
   const feedId = fid as string;
   const parentCommentId = cid as string;
+
+  useBnbHide();
 
   //바텀시트 open state
   const [openBTSheet, setOpenBTSheet] = useState<boolean>(false);

--- a/packages/climbingweb/pages/feed/[fid]/comments/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/index.tsx
@@ -14,6 +14,7 @@ import {
   useFindAllParentComment,
   useUpdateComment,
 } from 'climbingweb/src/hooks/queries/post/queryKey';
+import { useBnbHide } from 'climbingweb/src/hooks/useBnB';
 import { useIntersectionObserver } from 'climbingweb/src/hooks/useIntersectionObserver';
 import {
   CommentCreateRequest,
@@ -33,6 +34,8 @@ export default function CommentPage() {
   const router = useRouter();
   const { fid } = router.query;
   const feedId = fid as string;
+
+  useBnbHide();
 
   //바텀시트 open state
   const [openBTSheet, setOpenBTSheet] = useState<boolean>(false);

--- a/packages/climbingweb/src/components/Comments/CommentInput.tsx
+++ b/packages/climbingweb/src/components/Comments/CommentInput.tsx
@@ -64,7 +64,7 @@ export const CommentInput = ({
   };
 
   return (
-    <div className={'bg-gray-100 w-full flex p-4 fixed bottom-0 mb-footer '}>
+    <div className={'bg-gray-100 w-full flex p-4 fixed bottom-0'}>
       <div
         className={`w-full z-10 border-[1px] rounded-lg bg-white flex ${
           inputFocus ? 'border-purple-500' : 'border-gray-300'

--- a/packages/climbingweb/src/components/Comments/CommentInput.tsx
+++ b/packages/climbingweb/src/components/Comments/CommentInput.tsx
@@ -17,6 +17,21 @@ export const CommentInput = ({
   //등록 버튼 클릭 핸들러
   const [inputFocus, setInputFocus] = useState<boolean>(false);
 
+  /**
+   * textarea 높이를 지정하는 함수
+   *
+   * @param lineNumber textarea 높이를 지정할 줄 수, 지정하지 않을 경우 textarea.scrollHeight 로 지정 (현재 입력된 내용에 따라 높이가 달라짐)
+   */
+  const setTextAreatLine = (lineNumber?: number) => {
+    const textarea = refObj.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = lineNumber
+        ? INIT_TEXTAREA_SCROLL_HEIGHT * lineNumber + 'px'
+        : textarea.scrollHeight + 'px';
+    }
+  };
+
   const handleInputFocus = () => {
     setInputFocus(true);
   };
@@ -34,6 +49,7 @@ export const CommentInput = ({
         content: refObj.current?.value,
       });
       refObj.current.value = '';
+      setTextAreatLine();
     }
     setInputFocus(false);
   };
@@ -41,12 +57,10 @@ export const CommentInput = ({
   const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const textarea = e.target;
     if (textarea.scrollHeight > INPUT_FONT_SIZE * 5) {
-      textarea.style.height = 'auto';
-      textarea.style.height = INIT_TEXTAREA_SCROLL_HEIGHT * 3 + 'px';
+      setTextAreatLine(3);
       return;
     }
-    textarea.style.height = 'auto';
-    textarea.style.height = textarea.scrollHeight + 'px';
+    setTextAreatLine();
   };
 
   return (


### PR DESCRIPTION
## Related issue
#227 댓글 인풋창 버그

## Description
댓글 인풋창의 줄 수가 2줄 이상일 때, 댓글을 작성이 완료 되어도 기본 1줄로 돌아오지 않던 현상 수정

## Changes detail

- 댓글 인풋창의 줄 수가 2줄 이상일 때, 댓글을 작성이 완료 되어도 기본 1줄로 돌아오지 않던 현상 수정
  
![227](https://user-images.githubusercontent.com/37992140/218665990-149632ba-dc5f-4cd9-9b7a-7f4fbf473254.gif)

- 댓글 페이지, 대댓글 페이지 BNB 제거

### Checklist

- [ ] Test case
- [ ] End of work
