### PR TITLE
chore: firebase 캐시설정 추가

### DIFF
--- a/packages/climbingweb/firebase.json
+++ b/packages/climbingweb/firebase.json
@@ -2,5 +2,34 @@
   "hosting": {
     "source": ".",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
-  }
+  },
+  "headers": [
+    {
+      "source": "**/*.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=0, s-maxage=31536000"
+        }
+      ]
+    },
+    {
+      "source": "**/*.@(css|js)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=31536000"
+        }
+      ]
+    },
+    {
+      "source": "**/*.@(jpg|jpeg|gif|png)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=31536000"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Description
firebase 웹 서버 캐시 설정 추가

## Changes detail

-  html 
  -  브라우저 캐시 유지 시간 0, 항상 revalidate
  -  CDN에서 캐시 1년 유지,  
- css, js
  - 브라우저 캐시 1년
  - 새 빌드 시 파일 변경 => 캐시 무효화
- 그 외 리소스
  - 브라우저 캐시 1년
  - 프로젝트 내 리소스는 변경 가능성 없음 

### Checklist

- [ ] Test case
- [x] End of work
