### PR TITLE
fix:크로매틱 ci node 버전에 의한 에러 수정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,9 +9,20 @@ jobs:
   test:
     # the operating system it will run on
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
     # the list of steps that the action will go through
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
       - run: yarn
       - uses: chromaui/action@v1
         # options required to the GitHub chromatic action


### PR DESCRIPTION
## Description
크로매틱 ci 빌드 에러 해결

## Changes detail
-  firebase 캐시 설정 추가 커밋 이후 ci 빌드 에러 발생
-  원인은 node 버전 관련 에러 (위와 상관관계는 파악x)
-  ci에 노드버전 16 lts로 설정 후 해결

### Checklist

- [ ] Test case
- [x] End of work
