### PR TITLE
[CSS] 암장 리뷰

### DIFF
--- a/packages/climbingweb/pages/center/[cid]/review/index.tsx
+++ b/packages/climbingweb/pages/center/[cid]/review/index.tsx
@@ -22,17 +22,23 @@ export default function ReportPage() {
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const [rating, setRating] = useState(5);
+  const [rating, setRating] = useState<number>(5);
 
-  const { mutate: createReviewMutate } = useCreateReview(centerId);
+  const { mutate: createReviewMutate, isLoading } = useCreateReview(centerId, {
+    onSuccess: () => {
+      window.history.back();
+      toast('리뷰가 작성되었습니다.');
+    },
+    onError(error) {
+      toast(error.message);
+    },
+  });
 
   const handleSubmitClick = () => {
     createReviewMutate({
       content: textAreaRef.current?.value + '',
-      rank: rating,
+      rank: Math.floor(rating),
     });
-    toast('리뷰가 작성되었습니다.');
-    window.history.back();
   };
 
   const handleBackButtonClick = () => {
@@ -46,23 +52,25 @@ export default function ReportPage() {
         title=""
         rightNode={<Empty />}
       />
-      <div className="px-5 flex flex-col gap-4">
-        <div className="flex flex-col gap-2.5">
-          <h2 className="text-xl font-extrabold leading-6">
-            리뷰를 작성해주세요
-          </h2>
-          <StarRating
-            size="md"
-            count={count}
-            initialValue={5}
-            setData={setRating}
-          />
-          <TextArea
-            refObj={textAreaRef}
-            placeholder="요청 내용을 자세히 입력해주세요."
-          />
-        </div>
-        <NormalButton onClick={handleSubmitClick}>완료</NormalButton>
+      <div className="px-5">
+        <h2 className="text-xl font-extrabold leading-6 my-4">
+          리뷰를 작성해주세요
+        </h2>
+        <StarRating
+          size="md"
+          count={count}
+          initialValue={5}
+          setData={setRating}
+        />
+        <TextArea
+          className="h-[232px] text-sm my-5"
+          refObj={textAreaRef}
+          placeholder="500자 이내 리뷰 작성"
+          limitLength={500}
+        />
+        <NormalButton onClick={handleSubmitClick} disabled={isLoading}>
+          완료
+        </NormalButton>
       </div>
     </section>
   );

--- a/packages/climbingweb/src/components/common/StarRating/index.tsx
+++ b/packages/climbingweb/src/components/common/StarRating/index.tsx
@@ -8,7 +8,7 @@ interface RatingProps {
   setData?: Dispatch<SetStateAction<number>>;
 }
 
-export const StarRating = ({
+export const StarRatingHalf = ({
   count,
   readOnly = false,
   size = 'md',
@@ -41,7 +41,43 @@ export const StarRating = ({
           readOnly={readOnly}
           checked={value * 2 >= idx + 1}
           onChange={() => handleCheck(idx + 1)}
+          onClick={() => handleCheck(idx + 1)}
           className={star % 2 === 0 ? rightHalf : leftHalf}
+        />
+      ))}
+    </form>
+  );
+};
+
+export const StarRating = ({
+  count,
+  readOnly = false,
+  size = 'md',
+  initialValue,
+  setData,
+}: RatingProps) => {
+  const stars = Array(count).fill(1);
+
+  const [value, setValue] = useState(initialValue);
+
+  const handleCheck = (num: number) => {
+    if (!readOnly) setValue(num);
+    if (setData) setData(num);
+  };
+
+  return (
+    <form className={`rating rating-${size} rating relative`}>
+      {stars.map((star, idx) => (
+        <input
+          key={`rating${idx}`}
+          type="radio"
+          name="rating"
+          multiple
+          readOnly={readOnly}
+          checked={value === idx + 1}
+          onChange={() => handleCheck(idx + 1)}
+          onClick={() => handleCheck(idx + 1)}
+          className={'bg-yellow-500 mask mask-star-2'}
         />
       ))}
     </form>

--- a/packages/climbingweb/src/components/common/TextArea/TextArea.tsx
+++ b/packages/climbingweb/src/components/common/TextArea/TextArea.tsx
@@ -1,3 +1,4 @@
+import { useToast } from 'climbingweb/src/hooks/useToast';
 import { ChangeEvent } from 'react';
 
 interface ContentProps {
@@ -6,6 +7,7 @@ interface ContentProps {
   setData?: (content: string) => void;
   placeholder?: string;
   className?: string;
+  limitLength?: number;
 }
 
 export default function TextArea({
@@ -14,14 +16,20 @@ export default function TextArea({
   setData,
   placeholder,
   className,
+  limitLength,
 }: ContentProps) {
+  const { toast } = useToast();
   const onChangeValue = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    if (limitLength ? e.target.value.length > limitLength - 1 : false) {
+      toast(`${limitLength}자 이내로 작성해주세요.`);
+      return;
+    }
     if (setData) setData(e.target.value);
   };
 
   return (
     <div
-      className={`border  w-full border-gray resize-none rounded-lg p-4 ${className}`}
+      className={`border w-full border-gray resize-none rounded-lg p-4 ${className}`}
     >
       <textarea
         ref={refObj}
@@ -29,6 +37,7 @@ export default function TextArea({
         value={data}
         placeholder={placeholder}
         className=" w-full h-full placeholder:text-gray focus:outline-none resize-none"
+        maxLength={limitLength}
       />
     </div>
   );

--- a/packages/climbingweb/src/hooks/queries/center/queryKey.ts
+++ b/packages/climbingweb/src/hooks/queries/center/queryKey.ts
@@ -31,6 +31,7 @@ import {
   searchCenterName,
   updateReview,
 } from './queries';
+import { ServerBusinessError } from 'climbingweb/types/common';
 
 /**
  * center-controller api 의 query key factory
@@ -285,7 +286,12 @@ export const useSearchCenterName = (centerName: string) => {
 export const useCreateReview = (
   centerId: string,
   options?: Omit<
-    UseMutationOptions<ReviewResponse, unknown, ReviewCreateRequest, unknown>,
+    UseMutationOptions<
+      ReviewResponse,
+      ServerBusinessError,
+      ReviewCreateRequest,
+      unknown
+    >,
     'mutationFn'
   >
 ) => {


### PR DESCRIPTION
## Related issue
Fixes #250 

## Description
암장_리뷰_작성 페이지 CSS 적용 및 추가 로직 적용

## Changes detail

- StarRating 컴포넌트 변경
  해당 컴포넌트는 반별 표시가 되지 않도록 변경
- StarRatingHalf 컴포넌트 추가
  기존 StarRating 컴포넌트는 반별 표시가 되는 컴포넌트로, 이름을 StarRatingHalf 로 변경
- 암장_리뷰_작성 페이지 CSS 적용
  ![2](https://user-images.githubusercontent.com/37992140/220569731-99e1a6cd-00c9-4d88-ab24-997b4a1bdf14.gif)
- TextArea 컴포넌트 limitLength props 추가
  길이 제한을 넘길 경우 toast 메시지 적용
  ```
  toast(`${limitLength}자 이내로 작성해주세요.`);
  ```
- useCreateReview 에서 TError 타입 확정
  ServerBusinessError 로 확정 후 onError 시 나는 메시지를 toast 메시지로 출력하도록 변경 

### Checklist

- [ ] Test case
- [ ] End of work
