### PR TITLE
fix: 게시글 신고완료 시 홈_신고_완료 화면으로 redirect

### DIFF
--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -30,10 +30,11 @@ export default function ReportPage({}) {
 
   const { mutate: createCenterReportMutate } = useCreateReport(feedId, {
     onSuccess: () => {
-      toast('입력 완료 되었습니다.');
+      router.push('/');
+      toast('신고 완료');
     },
-    onError: () => {
-      toast('신고글 게시에 실패하였습니다.');
+    onError: (data: any) => {
+      toast(data.message);
     },
   });
 


### PR DESCRIPTION
## Related issue
Fixes #257 
## Description
fix: 게시글 신고완료 시 홈_신고_완료 화면으로 redirect
## Changes detail
- onSuccess시 router.push 추가 
- onError 시 Error message로 toast 변경

![#257](https://user-images.githubusercontent.com/42572954/220907986-c2e85934-9297-4d14-a160-937cdfac083a.gif)


### Checklist

- [ ] Test case
- [ ] End of work
