### PR TITLE
fix: 홈화면 댓글 더보기 등 터치 시 동작 버그 해결

### DIFF
--- a/packages/climbingweb/src/components/Comments/ReviewComment.tsx
+++ b/packages/climbingweb/src/components/Comments/ReviewComment.tsx
@@ -28,6 +28,8 @@ export const ReviewComment = ({
   const [readMore, setReadMore] = useState(false);
   const [realContent, setRealContent] = useState(content);
 
+  const handleReadMoreClick = () => setReadMore(!readMore);
+
   useEffect(() => {
     if (content.length > 67 && !readMore) {
       setRealContent(content.slice(0, 68));
@@ -57,7 +59,7 @@ export const ReviewComment = ({
           </p>
           <span
             className="text-gray-400 inline float-right text-sm"
-            onTouchEnd={() => setReadMore(!readMore)}
+            onClick={handleReadMoreClick}
           >
             {content.length > 67 ? (readMore ? '접기' : '더보기') : null}
           </span>
@@ -102,6 +104,8 @@ export const MyReviewComment = ({
       setRealContent(content);
     }
   }, [readMore, content]);
+
+  const handleReadMoreClick = () => setReadMore(!readMore);
 
   const handleModifyReviewClick = () => {
     changeReview({ content, rank });
@@ -153,7 +157,7 @@ export const MyReviewComment = ({
             className={`text-gray-400 inline text-sm ${
               readMore ? 'float-right' : null
             }`}
-            onTouchEnd={() => setReadMore(!readMore)}
+            onClick={handleReadMoreClick}
           >
             {content.length > 67 ? (readMore ? '접기' : '더보기') : null}
           </span>

--- a/packages/climbingweb/src/components/CreateFeed/CenterSearchInput.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/CenterSearchInput.tsx
@@ -109,7 +109,7 @@ export const CenterSearchInput = ({
             <div
               key={`searchInputForm_${index}`}
               className="text-sm font-medium hover:bg-[#EEEEEE] active:bg-[#EEEEEE] px-[21px] py-2"
-              onTouchEnd={() => handleSelected(val)}
+              onClick={() => handleSelected(val)}
             >
               {val.name}
             </div>

--- a/packages/climbingweb/src/components/HomeFeed/FeedContent/FeedContent.tsx
+++ b/packages/climbingweb/src/components/HomeFeed/FeedContent/FeedContent.tsx
@@ -40,7 +40,7 @@ const FeedContent = ({
         <span className={'flex font-medium items-center'}>
           {isLiked ? (
             <SolidHeart
-              onTouchEnd={onClickHeartIcon}
+              onClick={onClickHeartIcon}
               className="animate-larger mr-1"
               width="32px"
               height="32px"
@@ -48,7 +48,7 @@ const FeedContent = ({
             />
           ) : (
             <LineHeart
-              onTouchEnd={onClickHeartIcon}
+              onClick={onClickHeartIcon}
               className="animate-none mr-1 w-[32px] h-[32px]"
               width="32px"
               height="32px"
@@ -64,7 +64,7 @@ const FeedContent = ({
           <span className={' inline'}>{`${realContent}... `}</span>
           <span
             className="text-[#BFBFBF] inline block"
-            onTouchEnd={onTouchMoreRead}
+            onClick={onTouchMoreRead}
           >
             더 보기
           </span>
@@ -74,10 +74,7 @@ const FeedContent = ({
       )}
       {
         <div className="flex">
-          <p
-            onTouchEnd={onClickMoreComment}
-            className="font-medium text-gray-400"
-          >
+          <p onClick={onClickMoreComment} className="font-medium text-gray-400">
             {replyCount === 0 ? '댓글 달기' : `댓글 ${replyCount}개 더 보기`}
           </p>
         </div>

--- a/packages/climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet.tsx
+++ b/packages/climbingweb/src/components/common/BottomSheetContents/ListSheet/ListSheet.tsx
@@ -14,7 +14,7 @@ export const ListSheet = ({
         {list?.map((area) => (
           <p
             className={`${className}`}
-            onTouchEnd={() => onSelect(area)}
+            onClick={() => onSelect(area)}
             key={`areaKey${area}`}
           >
             {area}

--- a/packages/climbingweb/src/components/common/button/Button.tsx
+++ b/packages/climbingweb/src/components/common/button/Button.tsx
@@ -15,7 +15,7 @@ export const NormalButton = ({
     <button
       className={`w-full bg-purple-500 rounded-lg w-30 h-[56px] text-white active:bg-purple-400 disabled:bg-gray-300 disabled:text-gray-500 ${className}`}
       disabled={disabled}
-      onTouchEnd={onClick}
+      onClick={onClick}
     >
       {children}
     </button>
@@ -26,7 +26,7 @@ export const WhiteButton = ({ onClick, children, className }: ButtonProps) => {
   return (
     <button
       className={`w-full bg-gray-100 rounded-lg w-30 h-12 text-black active:bg-gray-200 ${className}`}
-      onTouchEnd={onClick}
+      onClick={onClick}
     >
       {children}
     </button>
@@ -40,7 +40,7 @@ export const SmmallNodeButton = ({
 }: ButtonProps) => {
   return (
     <button
-      onTouchEnd={onClick}
+      onClick={onClick}
       className={` w-10 h-6 bg-white border border-gray-300 rounded-lg text-xs ${className}`}
     >
       {children}


### PR DESCRIPTION
## Related issue
Fixes #289 

## Description
onClick 이벤트가 적절한 경우인데  onTouchEnd 이벤트로 리스너를 설정해서 스크롤링 시에 이벤트 오작동 하는 현상 해결

## Changes detail

- 각종 컴포넌트 중 onTouchEnd 이벤트가 굳이 필요없는 경우 onClick 으로 변경
- onTouchEnd 를 살린 경우는 onTouchStart 이벤트도 같이 있는 경우 살렸음 

### Checklist

- [ ] Test case
- [ ] End of work
