### PR TITLE
fix: 로그아웃 로직 수정, 탈퇴하기 기능 추가

### DIFF
--- a/packages/climbingapp/src/component/webview/CustomWebView.tsx
+++ b/packages/climbingapp/src/component/webview/CustomWebView.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { BackHandler, Linking, Platform, ToastAndroid } from 'react-native';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import { isJsonString } from 'climbingapp/src/utils/isJsonString';
+import axios from 'axios';
 interface WebInfo {
   url: string;
 }
@@ -39,6 +40,10 @@ export default function CustomWebView({ url }: WebInfo) {
   };
 
   useEffect(() => {
+    if (user) {
+      axios.defaults.headers.common['access-token'] = user.accessToken;
+      axios.defaults.headers.common['refresh-token'] = user.refreshToken;
+    }
     sendTokenToWebview();
   }, []);
 
@@ -52,7 +57,9 @@ export default function CustomWebView({ url }: WebInfo) {
     }
   };
 
-  const onMessageHandler = async ({ nativeEvent: state }: WebViewMessageEvent) => {
+  const onMessageHandler = async ({
+    nativeEvent: state,
+  }: WebViewMessageEvent) => {
     console.log(state.data);
     if (isJsonString(state.data)) {
       const data = JSON.parse(state.data);
@@ -84,9 +91,15 @@ export default function CustomWebView({ url }: WebInfo) {
   };
 
   useEffect(() => {
-    BackHandler.addEventListener('hardwareBackPress', onPressHardwareBackButton);
+    BackHandler.addEventListener(
+      'hardwareBackPress',
+      onPressHardwareBackButton
+    );
     return () => {
-      BackHandler.removeEventListener('hardwareBackPress', onPressHardwareBackButton);
+      BackHandler.removeEventListener(
+        'hardwareBackPress',
+        onPressHardwareBackButton
+      );
     };
   }, [isCanGoBack]);
 

--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -66,7 +66,7 @@ export const useAuth = () => {
 
   const leaveClaon = async () => {
     await axios
-      .delete(api + 'users/me')
+      .delete(api + '/users/me')
       .then(async (res) => {
         if (res.data?.errorCode) {
           const { errorCode, message }: ErrorResponse = res.data;

--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -43,12 +43,15 @@ export const useAuth = () => {
   const logout = async () => {
     await axios
       .post(api + '/auth/sign-out')
-      .then((res) => {
+      .then(async (res) => {
         if (res.data?.errorCode) {
           const { errorCode, message }: ErrorResponse = res.data;
           Alert.alert('에러' + errorCode, message + '');
         } else {
           signOut();
+          await storeData('access-token', '');
+          await storeData('refresh-token', '');
+          await storeData('isCompletedSignUp', '');
         }
       })
       .catch((error) => {
@@ -64,12 +67,15 @@ export const useAuth = () => {
   const leaveClaon = async () => {
     await axios
       .delete(api + 'users/me')
-      .then((res) => {
+      .then(async (res) => {
         if (res.data?.errorCode) {
           const { errorCode, message }: ErrorResponse = res.data;
           Alert.alert('에러' + errorCode, message + '');
         } else {
           signOut();
+          await storeData('access-token', '');
+          await storeData('refresh-token', '');
+          await storeData('isCompletedSignUp', '');
         }
       })
       .catch((error) => {

--- a/packages/climbingweb/pages/_app.tsx
+++ b/packages/climbingweb/pages/_app.tsx
@@ -4,52 +4,34 @@ import React, { useState } from 'react';
 import store from '../src/store';
 import { Provider } from 'react-redux';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import axios from 'axios';
 import 'react-spring-bottom-sheet/dist/style.css';
-import { useRNMessage } from 'climbingweb/src/hooks/useRNMessage';
 import { ToastClient } from 'climbingweb/src/components/common/Toast/ToastClient';
-import { useToken } from 'climbingweb/src/hooks/useToken';
-import Login from 'climbingweb/src/components/dev/Login';
-import { isDesktop } from 'react-device-detect';
+//import axios from 'axios';
+//import { useToken } from 'climbingweb/src/hooks/useToken';
+//import Login from 'climbingweb/src/components/dev/Login';
+//import { isDesktop } from 'react-device-detect';
 import NavBarWrapper from 'climbingweb/src/components/common/bottomNav/NavBarWrapper';
-import useIsomorphicLayoutEffect from 'climbingweb/src/hooks/useIsomorphicLayoutEffect';
+import { useAppToken } from 'climbingweb/src/hooks/useAppToken';
+import Loading from 'climbingweb/src/components/common/Loading/Loading';
 import { AnimatePresence } from 'framer-motion';
 function MyApp({ Component, pageProps, router }: AppProps) {
-  const { token, sendReactNativeMessage } = useRNMessage();
-  const { token: storageToken, isStorageLogin } = useToken();
-  useIsomorphicLayoutEffect(() => {
-    if (token) {
-      axios.defaults.headers.common['access-token'] = token.accessToken;
-      axios.defaults.headers.common['refresh-token'] = token.refreshToken;
-    }
-    if (isDesktop) {
-      axios.defaults.headers.common['access-token'] =
-        '' + process.env.NEXT_PUBLIC_ACCESS_TOKEN;
-      axios.defaults.headers.common['refresh-token'] =
-        '' + process.env.NEXT_PUBLIC_REFRESH_TOKEN;
-    }
-    if (isStorageLogin()) {
-      axios.defaults.headers.common['access-token'] = storageToken.accessToken;
-      axios.defaults.headers.common['refresh-token'] =
-        storageToken.refreshToken;
-    }
+  // const { token: storageToken, isStorageLogin } = useToken();
+  // useEffect(() => {
+  //   if (isDesktop) {
+  //     axios.defaults.headers.common['access-token'] =
+  //       '' + process.env.NEXT_PUBLIC_ACCESS_TOKEN;
+  //     axios.defaults.headers.common['refresh-token'] =
+  //       '' + process.env.NEXT_PUBLIC_REFRESH_TOKEN;
+  //   }
+  //   if (isStorageLogin()) {
+  //     axios.defaults.headers.common['access-token'] = storageToken.accessToken;
+  //     axios.defaults.headers.common['refresh-token'] =
+  //       storageToken.refreshToken;
+  //   }
+  //   //eslint-disable-next-line
+  // }, []);
 
-    axios.defaults.baseURL = '' + process.env.NEXT_PUBLIC_API;
-    axios.interceptors.response.use(function (response) {
-      if (response.headers?.hasOwnProperty('access-token')) {
-        sendReactNativeMessage({
-          type: 'updateToken',
-          payload: JSON.stringify({
-            'access-token': response.headers['access-token'],
-            'refresh-token': response.headers['refresh-token'],
-          }),
-        });
-      }
-      return response;
-    });
-
-    //eslint-disable-next-line
-  }, [token]);
+  const { token } = useAppToken();
 
   const [queryClient] = useState(
     () =>
@@ -63,10 +45,18 @@ function MyApp({ Component, pageProps, router }: AppProps) {
         },
       })
   );
-  if (!token && isDesktop && !isStorageLogin()) {
+  // if (!token && !isDesktop && !isStorageLogin()) {
+  //   return (
+  //     <section className=" h-screen flex justify-center items-center">
+  //       <Login />
+  //     </section>
+  //   );
+  // }
+
+  if (!token) {
     return (
       <section className=" h-screen flex justify-center items-center">
-        <Login />
+        <Loading />
       </section>
     );
   }

--- a/packages/climbingweb/pages/setting/index.tsx
+++ b/packages/climbingweb/pages/setting/index.tsx
@@ -95,7 +95,7 @@ export default function SettingPage() {
       setOpenSheet(false);
     } else if (sheetKey === 'leave') {
       //회원 탈퇴
-      //deleteUserMutate();
+      sendReactNativeMessage({ type: 'leave' });
       setOpenSheet(false);
     }
   };

--- a/packages/climbingweb/src/hooks/useAppToken.ts
+++ b/packages/climbingweb/src/hooks/useAppToken.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
+import { useRNMessage } from './useRNMessage';
+
+export const useAppToken = () => {
+  const { token, sendReactNativeMessage } = useRNMessage();
+
+  useIsomorphicLayoutEffect(() => {
+    if (token) {
+      axios.defaults.headers.common['access-token'] = token.accessToken;
+      axios.defaults.headers.common['refresh-token'] = token.refreshToken;
+    }
+
+    axios.defaults.baseURL = '' + process.env.NEXT_PUBLIC_API;
+    axios.interceptors.response.use(function (response) {
+      if (response.headers?.hasOwnProperty('access-token')) {
+        sendReactNativeMessage({
+          type: 'updateToken',
+          payload: JSON.stringify({
+            'access-token': response.headers['access-token'],
+            'refresh-token': response.headers['refresh-token'],
+          }),
+        });
+      }
+      return response;
+    });
+  }, [token]);
+
+  return {
+    token,
+  };
+};

--- a/packages/climbingweb/src/hooks/useToken.ts
+++ b/packages/climbingweb/src/hooks/useToken.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 
 interface Token {
@@ -53,6 +54,8 @@ export const useToken = () => {
     try {
       window.localStorage.removeItem('accessToken');
       window.localStorage.removeItem('refreshToken');
+      axios.defaults.headers.common['access-token'] = '';
+      axios.defaults.headers.common['refresh-token'] = '';
       location.reload();
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
## Related issue
Fixes 
#288 
#296
#297

## Description
- 로그아웃 오류 fix
- 홈 화면 최초 접속 시 토큰 오류 fix
- 회원탈퇴 기능 추가 feat 
## Changes detail
- 로그아웃
  -  로그아웃 해도 디바이스에  기존 토큰을 지우지 않고 남겨놔서 발생한 버그
  -  기존 토큰을 지우고 정상 로그인 플로우를 통해 새 토큰을 발급받도록 함 
- 홈 화면
  - 웹 접속용 토큰 관련 로직을 주석처리
  - 앱에서 토큰 받아오는 로직  hook으로 분리
  - 화면 분기처리
  -  ** 기존에 화면 분기처리가 되지 않은 이유는 토큰이 정상적으로 axios header에 저장되기 전에 home 화면에 진입했기 때문에  api error call 화면을 띄움**
- 회원탈퇴
  -  앱에 leave 메시지 전달
  -  기존에 얍애소 작성한 회원탈퇴 로직을 통해 기능 수행  
## ScreenShot
![로그아웃, 회원탈퇴](https://user-images.githubusercontent.com/33804074/223345926-a91bb94c-ea30-4528-be63-330a09f736a2.gif)


### Checklist

- [ ] Test case
- [x] End of work
