### PR TITLE
fix: 가입완료 화면 헤더(뒤로가기) 제거, 입력정보 초기화

### DIFF
--- a/packages/climbingapp/src/navigation/LoginNavigator.tsx
+++ b/packages/climbingapp/src/navigation/LoginNavigator.tsx
@@ -77,7 +77,11 @@ const LoginNavigator = () => {
         component={ConnectWithInstagramScreen}
         options={{ animation: 'slide_from_right' }}
       />
-      <Stack.Screen name="welcome" component={WelcomeScreen} />
+      <Stack.Screen
+        name="welcome"
+        component={WelcomeScreen}
+        options={{ headerShown: false }}
+      />
       <Stack.Screen
         name="instagram"
         initialParams={instagramInitalValue}

--- a/packages/climbingapp/src/navigation/screens/auth/WelcomeScreen.tsx
+++ b/packages/climbingapp/src/navigation/screens/auth/WelcomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import LottieView from 'lottie-react-native';
 import { ScreenView } from 'climbingapp/src/component/view/ScreenView';
 import Assets from 'climbingapp/src/assets/lottie';
@@ -8,6 +8,8 @@ import { Title } from 'climbingapp/src/component/text/AuthTitle';
 import { TouchableHighlight } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { LoginScreenProp } from './type';
+import { initUserInfo } from 'climbingapp/src/store/slices/authInfo';
+import { useDispatch } from 'react-redux';
 
 const Container = styled.View`
   flex: 0.8;
@@ -25,6 +27,13 @@ const Text = styled.Text`
 function WelcomeScreen() {
   const name = '닉네임';
   const navigation = useNavigation<LoginScreenProp>();
+  const dispatch = useDispatch();
+
+  // 회원가입 입력 정보 초기화
+  useEffect(() => {
+    dispatch(initUserInfo());
+  }, []);
+
   const handleGoToMain = () => {
     navigation.reset({ routes: [{ name: 'home' }] });
   };

--- a/packages/climbingapp/src/store/slices/authInfo.ts
+++ b/packages/climbingapp/src/store/slices/authInfo.ts
@@ -44,6 +44,9 @@ const authInfoSlice = createSlice({
     setImagePath(state, action: PayloadAction<string>) {
       state.userInfo.imagePath = action.payload;
     },
+    initUserInfo(state) {
+      state.userInfo = initialState.userInfo;
+    },
   },
 });
 
@@ -54,4 +57,5 @@ export const {
   setInstagram,
   setImagePath,
   setNickName,
+  initUserInfo,
 } = authInfoSlice.actions;


### PR DESCRIPTION
## Description
- 회원 가입 완료 화면에서 뒤로가기가 존재 => 제거
- 가입 완료 시 리덕스에 저장되어있던 회원가입용 입력정보 모두 초기화

### Checklist

- [ ] Test case
- [x] End of work
