### PR TITLE
feat: google 로그인 기록 삭제 적용

### DIFF
--- a/packages/climbingapp/src/component/webview/CustomWebView.tsx
+++ b/packages/climbingapp/src/component/webview/CustomWebView.tsx
@@ -60,13 +60,11 @@ export default function CustomWebView({ url }: WebInfo) {
   const onMessageHandler = async ({
     nativeEvent: state,
   }: WebViewMessageEvent) => {
-    console.log(state.data);
     if (isJsonString(state.data)) {
       const data = JSON.parse(state.data);
       if (data.type === 'updateToken') {
         handleUpdateToken(data);
       } else if (data.type === 'logout') {
-        console.log('sdsdfsd');
         await logout()
           .then(() => {
             if (Platform.OS === 'android') {

--- a/packages/climbingapp/src/hooks/useAuth.ts
+++ b/packages/climbingapp/src/hooks/useAuth.ts
@@ -129,13 +129,17 @@ export const useAuth = () => {
     }
   };
 
-  const googleLogin = async () => {
+  const googleConfigure = () => {
     GoogleSignin.configure({
       offlineAccess: true,
       hostedDomain: '',
       webClientId: Config.GOOGLE_WEB_CLIENT_ID,
       iosClientId: Config.GOOGLE_IOS_CLIENT_ID,
     });
+  };
+
+  const googleLogin = async () => {
+    googleConfigure();
     try {
       await GoogleSignin.hasPlayServices();
       const { idToken: code } = await GoogleSignin.signIn();
@@ -144,6 +148,15 @@ export const useAuth = () => {
       }
     } catch (err) {
       console.log(err);
+    }
+  };
+
+  // google 로그인 기록 취소 함수
+  const googleSignOut = async () => {
+    googleConfigure();
+    const isSignedIn = await GoogleSignin.isSignedIn();
+    if (isSignedIn) {
+      await GoogleSignin.signOut();
     }
   };
   // const AppleLogin = () => {}
@@ -155,5 +168,6 @@ export const useAuth = () => {
     kakaoLogin,
     logout,
     googleLogin,
+    googleSignOut,
   };
 };

--- a/packages/climbingapp/src/navigation/screens/auth/LoginScreen.tsx
+++ b/packages/climbingapp/src/navigation/screens/auth/LoginScreen.tsx
@@ -7,7 +7,7 @@ import {
 } from 'climbingapp/src/component/button/buttonProps';
 import { ScreenView } from 'climbingapp/src/component/view/ScreenView';
 import { colorStyles } from 'climbingapp/src/styles';
-import React from 'react';
+import React, { useEffect } from 'react';
 //import { Platform } from 'react-native';
 import styled from 'styled-components/native';
 import { LoginScreenProp } from './type';
@@ -38,20 +38,20 @@ const ButtonContainer = styled.View`
   flex: ${Platform.OS === 'ios' ? 0.5 : 0.3};
 `;
 
-const KakaoButton = ({ onPress }: { onPress: ({ }: any) => void }) => {
+const KakaoButton = ({ onPress }: { onPress: ({}: any) => void }) => {
   return <DefaultButton {...Kakao} onPress={onPress} />;
 };
 
-const AppleButton = ({ onPress }: { onPress: ({ }: any) => void }) => {
+const AppleButton = ({ onPress }: { onPress: ({}: any) => void }) => {
   return <DefaultButton {...Apple} onPress={onPress} />;
 };
-const GoogleButton = ({ onPress }: { onPress: ({ }: any) => void }) => {
+const GoogleButton = ({ onPress }: { onPress: ({}: any) => void }) => {
   return <DefaultButton {...Google} onPress={onPress} />;
 };
 function LoginScreen() {
   const navigation = useNavigation<LoginScreenProp>();
 
-  const { kakaoLogin, googleLogin } = useAuth();
+  const { kakaoLogin, googleLogin, googleSignOut } = useAuth();
 
   const handleAfterOAuth = (res: void | User | ErrorResponse) => {
     if (res) {
@@ -69,6 +69,10 @@ function LoginScreen() {
       }
     }
   };
+
+  useEffect(() => {
+    googleSignOut();
+  }, []);
 
   const handleSignApple = () => {
     Alert.alert('애플로그인은 현재 준비 중입니다.');


### PR DESCRIPTION
## Related issue
Fixes #287 

## Description
- 로그인 화면에서 구글 로그인 기록 삭제 => 다른 구글 아이디로 로그인 가능하도록 fix

## Changes detail
- googleSignOut 함수 사용
  - revokeAccess => signOut 으로 변경
  - revokeAccess는 유저가 어플에 접근하는 권한도 없앰 => signout만 해도 로그인 변경에 충분함
  - 이 외 revokeAccess 사용 시 발생되는 부가적인 이슈는 파악 안되었음 
- 로그인 화면 마운트 시 동작


### Checklist

- [ ] Test case
- [x] End of work
