### PR TITLE
fix: 입력 화면에서 필수 입력 부분 에러 메시지 확인 방법 변경

### DIFF
--- a/packages/climbingweb/pages/center/[cid]/review/[rid].tsx
+++ b/packages/climbingweb/pages/center/[cid]/review/[rid].tsx
@@ -9,6 +9,7 @@ import TextArea from 'climbingweb/src/components/common/TextArea/TextArea';
 import { useUpdateReview } from 'climbingweb/src/hooks/queries/center/queryKey';
 import { useGetReview } from 'climbingweb/src/hooks/useReview';
 import { useToast } from 'climbingweb/src/hooks/useToast';
+import { getErrorMessageToResponse } from 'climbingweb/src/utils/getErrorMessageToResponse';
 import router from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -33,7 +34,7 @@ export default function ReportEditPage() {
         toast('리뷰가 수정되었습니다.');
       },
       onError(error: any) {
-        toast(error.message);
+        toast(getErrorMessageToResponse(error));
       },
     }
   );

--- a/packages/climbingweb/pages/center/[cid]/review/index.tsx
+++ b/packages/climbingweb/pages/center/[cid]/review/index.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import { useCreateReview } from 'climbingweb/src/hooks/queries/center/queryKey';
 import { useRef, useState } from 'react';
 import { useToast } from 'climbingweb/src/hooks/useToast';
+import { getErrorMessageToResponse } from 'climbingweb/src/utils/getErrorMessageToResponse';
 
 export default function ReportPage() {
   const router = useRouter();
@@ -30,7 +31,7 @@ export default function ReportPage() {
       toast('리뷰가 작성되었습니다.');
     },
     onError(error) {
-      toast(error.message);
+      toast(getErrorMessageToResponse(error));
     },
   });
 

--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -14,6 +14,7 @@ import { useCreateReport } from 'climbingweb/src/hooks/queries/post/queryKey';
 import { useToast } from 'climbingweb/src/hooks/useToast';
 import { useBnbHide } from 'climbingweb/src/hooks/useBnB';
 import PageLoading from 'climbingweb/src/components/common/Loading/PageLoading';
+import { getErrorMessageToResponse } from 'climbingweb/src/utils/getErrorMessageToResponse';
 
 export default function ReportPage({}) {
   const router = useRouter();
@@ -38,7 +39,7 @@ export default function ReportPage({}) {
       toast('신고 완료');
     },
     onError: (data: any) => {
-      toast(data.message);
+      toast(getErrorMessageToResponse(data));
     },
   });
 

--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -38,8 +38,8 @@ export default function ReportPage({}) {
       router.push('/');
       toast('신고 완료');
     },
-    onError: (data: any) => {
-      toast(getErrorMessageToResponse(data));
+    onError: (error) => {
+      toast(getErrorMessageToResponse(error));
     },
   });
 

--- a/packages/climbingweb/pages/search/index.tsx
+++ b/packages/climbingweb/pages/search/index.tsx
@@ -69,8 +69,6 @@ const SearchPage = () => {
     { threshold: 1 }
   );
 
-  console.dir(searchCenterList);
-
   return (
     <div className="w-full flex flex-col item-center 'mb-footer overflow-auto scrollbar-hide'">
       <AppBar leftNode={<AppLogo />} />

--- a/packages/climbingweb/src/components/CreateFeed/CenterSearchInput.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/CenterSearchInput.tsx
@@ -68,6 +68,7 @@ export const CenterSearchInput = ({
 
   // option list 중 하나를 선택 했을 때 handler
   const handleSelected = (val: CenterNameResponse) => {
+    console.dir('handleSelected');
     setInputValue(val.name);
     if (setData) setData(val.name, val.id);
     setSelected(true);
@@ -109,7 +110,7 @@ export const CenterSearchInput = ({
             <div
               key={`searchInputForm_${index}`}
               className="text-sm font-medium hover:bg-[#EEEEEE] active:bg-[#EEEEEE] px-[21px] py-2"
-              onClick={() => handleSelected(val)}
+              onTouchEnd={() => handleSelected(val)}
             >
               {val.name}
             </div>

--- a/packages/climbingweb/src/components/CreateFeed/CenterSearchInput.tsx
+++ b/packages/climbingweb/src/components/CreateFeed/CenterSearchInput.tsx
@@ -68,7 +68,6 @@ export const CenterSearchInput = ({
 
   // option list 중 하나를 선택 했을 때 handler
   const handleSelected = (val: CenterNameResponse) => {
-    console.dir('handleSelected');
     setInputValue(val.name);
     if (setData) setData(val.name, val.id);
     setSelected(true);

--- a/packages/climbingweb/src/components/SettingInfo/EditMyInfo.tsx
+++ b/packages/climbingweb/src/components/SettingInfo/EditMyInfo.tsx
@@ -109,7 +109,6 @@ export const EditMyInfo = ({ userRequest }: InfoProps) => {
   const handleModifyButtonClick = () => {
     if (userImageFile) uploadUserImageMutate([userImageFile]);
     else {
-      console.dir('no image');
       modifyUserMutate(userRequestData);
     }
   };

--- a/packages/climbingweb/src/components/common/Error/ErrorContent.tsx
+++ b/packages/climbingweb/src/components/common/Error/ErrorContent.tsx
@@ -1,4 +1,4 @@
-import { ServerBusinessError, ServerError } from 'climbingweb/types/common';
+import { getErrorMessageToResponse } from 'climbingweb/src/utils/getErrorMessageToResponse';
 import React from 'react';
 
 interface ErrorContentProps {
@@ -7,14 +7,7 @@ interface ErrorContentProps {
 
 // 공통 error 컴포넌트, 추후 변경 예정
 const ErrorContent = ({ error }: ErrorContentProps) => {
-  const target = error as ServerError | ServerBusinessError;
-  if (target.hasOwnProperty('errorCode')) {
-    const { message } = error as ServerBusinessError;
-    return <div>{message}</div>;
-  } else {
-    const { error: message } = error as ServerError;
-    return <div>{message}</div>;
-  }
+  return <div>{getErrorMessageToResponse(error)}</div>;
 };
 
 export default ErrorContent;

--- a/packages/climbingweb/src/components/common/TextArea/TextArea.tsx
+++ b/packages/climbingweb/src/components/common/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import { useToast } from 'climbingweb/src/hooks/useToast';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 interface ContentProps {
   refObj?: React.RefObject<HTMLTextAreaElement>;
@@ -19,17 +19,23 @@ export default function TextArea({
   limitLength,
 }: ContentProps) {
   const { toast } = useToast();
+  const [isMaxLength, setIsMaxLength] = useState<boolean>(false);
+
   const onChangeValue = (e: ChangeEvent<HTMLTextAreaElement>) => {
     if (limitLength ? e.target.value.length > limitLength - 1 : false) {
       toast(`${limitLength}자 이내로 작성해주세요.`);
+      setIsMaxLength(true);
       return;
     }
+    if (isMaxLength) setIsMaxLength(false);
     if (setData) setData(e.target.value);
   };
 
   return (
     <div
-      className={`border w-full border-gray resize-none rounded-lg p-4 ${className}`}
+      className={`border w-full ${
+        isMaxLength ? 'border-red-500' : 'border-gray'
+      } resize-none rounded-lg p-4 ${className}`}
     >
       <textarea
         ref={refObj}

--- a/packages/climbingweb/src/components/common/TextArea/TextArea.tsx
+++ b/packages/climbingweb/src/components/common/TextArea/TextArea.tsx
@@ -35,13 +35,13 @@ export default function TextArea({
     <div
       className={`border w-full ${
         isMaxLength ? 'border-red-500' : 'border-gray'
-      } resize-none rounded-lg p-4 ${className}`}
+      } resize-none rounded-lg p-1 ${className}`}
     >
       <textarea
         ref={refObj}
         onChange={onChangeValue}
         placeholder={placeholder}
-        className=" w-full h-full placeholder:text-gray focus:outline-none resize-none"
+        className=" w-full h-full placeholder:text-gray focus:outline-none resize-none p-3 scroll-m-0"
         maxLength={limitLength}
         defaultValue={data}
       />

--- a/packages/climbingweb/src/utils/getErrorMessageToResponse.ts
+++ b/packages/climbingweb/src/utils/getErrorMessageToResponse.ts
@@ -4,9 +4,8 @@ export const getErrorMessageToResponse = (error: unknown) => {
   const target = error as ServerError | ServerBusinessError;
   if (target.hasOwnProperty('errorCode')) {
     const serverBusinessError = target as ServerBusinessError;
-    console.dir('serverBusinessError');
     if (serverBusinessError.violations) {
-      return serverBusinessError.violations.join(', ');
+      return serverBusinessError.violations[0];
     } else {
       return serverBusinessError.message;
     }

--- a/packages/climbingweb/src/utils/getErrorMessageToResponse.ts
+++ b/packages/climbingweb/src/utils/getErrorMessageToResponse.ts
@@ -1,0 +1,18 @@
+import { ServerBusinessError, ServerError } from 'climbingweb/types/common';
+
+export const getErrorMessageToResponse = (error: unknown) => {
+  const target = error as ServerError | ServerBusinessError;
+  if (target.hasOwnProperty('errorCode')) {
+    const serverBusinessError = target as ServerBusinessError;
+    console.dir('serverBusinessError');
+    if (serverBusinessError.violations) {
+      return serverBusinessError.violations.join(', ');
+    } else {
+      return serverBusinessError.message;
+    }
+  } else if (target.hasOwnProperty('error')) {
+    const serverError = error as ServerError;
+    return serverError.error;
+  }
+  return '알수 없는 에러';
+};


### PR DESCRIPTION
## Related issue
Fixes #292 

## Description
- 서버 에러 응답 처리 방법 리팩터링

## Changes detail

- 서버 에러 응답 처리 방법 리팩터링
  에러 응답에서 메시지 string 으로 가져오는 공통 util 함수 추가 및 적용

- 리뷰 500자 초과 시 textarea 빨간색 border 및 toast 처리
  ![292](https://user-images.githubusercontent.com/37992140/223983476-9e4c3cfe-5503-4c17-a4c3-ca07626b53b7.gif)


### Checklist

- [ ] Test case
- [ ] End of work
