### PR TITLE
fix: bottomsheet에 pointer-event props로 직접 변경해주어 backdrop 뒤 화면 클릭 방지

### DIFF
--- a/packages/climbingweb/pages/center/[cid]/index.tsx
+++ b/packages/climbingweb/pages/center/[cid]/index.tsx
@@ -64,7 +64,11 @@ export default function CenterDetailPage() {
           />
           <CenterInfoContent data={CenterDetailData} />
         </SlideRight>
-        <BottomSheet open={openBTSheet} onDismiss={() => setOpenBTSheet(false)}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={openBTSheet}
+          onDismiss={() => setOpenBTSheet(false)}
+        >
           <ListSheet
             headerTitle={''}
             list={['수정 요청']}

--- a/packages/climbingweb/pages/center/request/[cid].tsx
+++ b/packages/climbingweb/pages/center/request/[cid].tsx
@@ -127,7 +127,11 @@ export default function ReportPage({}) {
           완료
         </NormalButton>
       </div>
-      <BottomSheet open={open} onDismiss={handleDismiss}>
+      <BottomSheet
+        style={{ pointerEvents: 'auto' }}
+        open={open}
+        onDismiss={handleDismiss}
+      >
         <ListSheet
           headerTitle={header}
           list={reportList}

--- a/packages/climbingweb/pages/feed/[fid].tsx
+++ b/packages/climbingweb/pages/feed/[fid].tsx
@@ -141,7 +141,11 @@ export default function FeedPage({}) {
           <AppBar leftNode={<BackButton onClick={handleBackButtonClick} />} />
           <HomeFeed postData={postData} openBtSheet={openBtSheet} />
         </SlideRight>
-        <BottomSheet open={open} onDismiss={onDismiss}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={open}
+          onDismiss={onDismiss}
+        >
           {'isOwner' in postData && postData.isOwner ? (
             openDelete ? (
               <ButtonSheet

--- a/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/[cid]/index.tsx
@@ -220,14 +220,17 @@ export default function CommentDetailPage() {
           parentCommentId={parentCommentId}
           onClickSubmit={handleSubmitCommentClick}
         />
-        <BottomSheet open={openBTSheet} onDismiss={() => setOpenBTSheet(false)}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={openBTSheet}
+          onDismiss={() => setOpenBTSheet(false)}
+        >
           <ButtonSheet
             text="댓글을 삭제하시겠습니까?"
             onCancel={() => setOpenBTSheet(false)}
             onConfirm={handleConfirmBTSheet}
           />
         </BottomSheet>
-
       </div>
     );
   }

--- a/packages/climbingweb/pages/feed/[fid]/comments/index.tsx
+++ b/packages/climbingweb/pages/feed/[fid]/comments/index.tsx
@@ -131,8 +131,7 @@ export default function CommentPage() {
 
   if (commentData)
     return (
-      <div
-        className="mb-footer overflow-auto scrollbar-hide">
+      <div className="mb-footer overflow-auto scrollbar-hide">
         <SlideRight>
           <div className="mb-footer">
             <AppBar
@@ -170,7 +169,11 @@ export default function CommentPage() {
           refObj={commentInputRef}
           onClickSubmit={handleSubmitComment}
         />
-        <BottomSheet open={openBTSheet} onDismiss={() => setOpenBTSheet(false)}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={openBTSheet}
+          onDismiss={() => setOpenBTSheet(false)}
+        >
           <ButtonSheet
             text="댓글을 삭제하시겠습니까?"
             onCancel={() => setOpenBTSheet(false)}

--- a/packages/climbingweb/pages/index.tsx
+++ b/packages/climbingweb/pages/index.tsx
@@ -118,7 +118,11 @@ const Home: NextPage = () => {
         ) : (
           <Loading />
         )}
-        <BottomSheet open={open} onDismiss={onDismiss}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={open}
+          onDismiss={onDismiss}
+        >
           <ListSheet
             headerTitle={''}
             list={['신고하기']}

--- a/packages/climbingweb/pages/report/[fid].tsx
+++ b/packages/climbingweb/pages/report/[fid].tsx
@@ -104,7 +104,11 @@ export default function ReportPage({}) {
           완료
         </NormalButton>
       </div>
-      <BottomSheet open={open} onDismiss={handleDismiss}>
+      <BottomSheet
+        style={{ pointerEvents: 'auto' }}
+        open={open}
+        onDismiss={handleDismiss}
+      >
         <ListSheet
           headerTitle={'신고 사유'}
           list={['부적절한 게시글', '부적절한 닉네임', '잘못된 암장 선택']}

--- a/packages/climbingweb/pages/setting/index.tsx
+++ b/packages/climbingweb/pages/setting/index.tsx
@@ -147,7 +147,11 @@ export default function SettingPage() {
             {titleName === '개인정보 처리 방침' && <>개인정보 처리 방침</>}
           </div>
         </SlideRight>
-        <BottomSheet open={openSheet} onDismiss={onBottomSheetDismiss}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={openSheet}
+          onDismiss={onBottomSheetDismiss}
+        >
           <ButtonSheet
             text={
               sheetKey === 'leave'

--- a/packages/climbingweb/pages/users/name/[uname]/index.tsx
+++ b/packages/climbingweb/pages/users/name/[uname]/index.tsx
@@ -178,7 +178,11 @@ export default function UserPage({}) {
             isPrivate={getUserData.isPrivate}
           />
         </SlideRight>
-        <BottomSheet open={openSheet} onDismiss={() => onBottomSheetDismiss()}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={openSheet}
+          onDismiss={() => onBottomSheetDismiss()}
+        >
           <ListSheet
             headerTitle=""
             list={[getUserData.isLaon ? '라온 취소 및 차단하기' : '차단하기']}

--- a/packages/climbingweb/src/components/SettingInfo/BanList.tsx
+++ b/packages/climbingweb/src/components/SettingInfo/BanList.tsx
@@ -97,7 +97,11 @@ export const BanList = ({}) => {
         ) : (
           <Loading />
         )}
-        <BottomSheet open={openSheet} onDismiss={handleDismiss}>
+        <BottomSheet
+          style={{ pointerEvents: 'auto' }}
+          open={openSheet}
+          onDismiss={handleDismiss}
+        >
           <ButtonSheet
             text={`${selectedUser} 님을 차단 해제 하시겠습니까?`}
             onConfirm={handleDeleteBlockConfirmButtonClick}


### PR DESCRIPTION
## Related issue
Fixes 
#238
#291 

## Description
- 바텀시트 오픈 되었을 때 backdrop 뒤 화면의 클릭 발생하지 않도록 fix

## Changes detail
- 바텀시트 style props에 직접 pointer-event 속성을 설정 =>  auto
  - 꼭 auto 옵션이 아니어도 클릭 이슈 해결 되었음 

### Checklist

- [ ] Test case
- [x] End of work
